### PR TITLE
Release v0.4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
         run: uv sync --dev
 
       - name: Run tests
-        run: uv run pytest --cov=gobby --cov-report=xml --cov-report=term-missing --cov-fail-under=80 --deselect tests/hooks/test_hooks_context.py::test_session_start_context_injection
+        run: uv run pytest --cov=gobby --cov-report=xml --cov-report=term-missing --cov-fail-under=80 --ignore=tests/voice --ignore=tests/servers/routes/test_voice_routes.py --deselect tests/hooks/test_hooks_context.py::test_session_start_context_injection
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.13'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,10 +241,17 @@ jobs:
       - name: Check package contents
         run: |
           uv run python -c "
-          import tarfile, glob
-          files = glob.glob('dist/gobby-*.tar.gz')
-          if not files:
+          import glob, tarfile, zipfile
+          sdists = glob.glob('dist/gobby-*.tar.gz')
+          wheels = glob.glob('dist/gobby-*.whl')
+          if not sdists:
               raise FileNotFoundError('No dist/gobby-*.tar.gz found')
-          t = tarfile.open(files[0])
+          if not wheels:
+              raise FileNotFoundError('No dist/gobby-*.whl found')
+          t = tarfile.open(sdists[0])
           print('\\n'.join(t.getnames()[:20]))
+          with zipfile.ZipFile(wheels[0]) as wheel:
+              names = set(wheel.namelist())
+          if 'gobby/ui/web/dist/index.html' not in names:
+              raise FileNotFoundError('Wheel missing gobby/ui/web/dist/index.html')
           "

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         run: uv sync --dev
 
       - name: Run tests
-        run: uv run pytest --deselect tests/hooks/test_hooks_context.py::test_session_start_context_injection
+        run: uv run pytest --ignore=tests/voice --ignore=tests/servers/routes/test_voice_routes.py --deselect tests/hooks/test_hooks_context.py::test_session_start_context_injection
 
   build:
     name: Build package

--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,6 @@ package-lock.json
 
 # MCP config (contains machine-specific absolute paths)
 .mcp.json
+
+# Built web UI assets staged into the wheel by build_backend (regenerated each build)
+src/gobby/ui/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ All notable changes to Gobby are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2]
+
+A patch release focused on packaging correctness for installed wheels, custom
+embedding endpoints, and cleanup of early 0.4.x install rough edges.
+
+### Added
+
+- Add `gobby install --embedding-url`, `--embedding-model`, and
+  `--embedding-dim` support for custom OpenAI-compatible embedding endpoints,
+  including interactive install prompts and automatic dimension probing (#9,
+  #14514).
+
+### Fixed
+
+- Ship the built web UI inside published wheels and serve installed-wheel UI
+  traffic from the daemon port at `http://localhost:60887/`, while keeping
+  `:60889` documented as the frontend development server port (#10, #14512,
+  #14515).
+- Verify built wheels contain `gobby/ui/web/dist/index.html` and include the
+  custom PEP 517 build backend in sdists so wheel-from-sdist builds cannot
+  silently lose the production UI (#10, #14515).
+- Honor explicit custom embedding URLs even when no local LM Studio or Ollama
+  service is detected, infer Ollama-compatible endpoints on `:11434`, and skip
+  bundled local setup when users provide their own endpoint or model (#9,
+  #14515).
+- Rename the global MCP server config from `~/.gobby/.mcp.json` to
+  `~/.gobby/mcp-servers.json` with idempotent migration, avoiding collisions
+  with Claude Code's project `.mcp.json` schema (#11, #14513).
+- Keep main pytest jobs from pulling the heavy voice extra path while preserving
+  dedicated voice validation coverage (#14511).
+
+### Release
+
+- Bump the package and `src/gobby/__init__.py` version to 0.4.2 and regenerate
+  the workspace lockfile entry (#14510).
+
 ## [0.4.1]
 
 A patch release on top of `0.4.0` focused on daemon stability, runner

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include build_backend/__init__.py

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ have are missing.
 ## What Gobby is
 
 A Python 3.13+ daemon you run locally. SQLite at `~/.gobby/gobby-hub.db`.
-HTTP on `:60887`, WebSocket on `:60888`, web UI on `:60889`, stdio MCP server
-that your coding CLIs talk to.
+HTTP and the installed web UI on `:60887`, WebSocket on `:60888`, dev web UI
+on `:60889`, stdio MCP server that your coding CLIs talk to.
 
 Three things make Gobby load-bearing:
 
@@ -225,7 +225,8 @@ Full release notes: [CHANGELOG.md](CHANGELOG.md).
 
 - Python 3.13+ daemon (`uv` for everything)
 - SQLite at `~/.gobby/gobby-hub.db`
-- HTTP API on `localhost:60887`, WebSocket on `:60888`, web UI on `:60889`
+- HTTP API and installed web UI on `localhost:60887`, WebSocket on `:60888`,
+  dev web UI on `:60889`
 - stdio MCP server for coding assistants
 - Hook adapters for Claude Code, Codex, Gemini CLI, Qwen CLI, Factory Droid
 - Optional Qdrant + FalkorDB for vector and graph-backed search
@@ -318,7 +319,8 @@ gobby init                   # initialize .gobby/ for this repo
 }
 ```
 
-Open the local web UI at `http://localhost:60889` once the daemon is running.
+Open the installed web UI at `http://localhost:60887/` once the daemon is running.
+The `:60889` UI port is for `gobby ui dev` during frontend development.
 
 Then either start interactive work in your CLI of choice — Gobby will track it
 quietly — or hand it a task and let the build loop run:

--- a/build_backend/__init__.py
+++ b/build_backend/__init__.py
@@ -1,0 +1,97 @@
+"""PEP 517 build backend wrapper.
+
+Wraps setuptools.build_meta to stage the web UI into the wheel.
+
+Before every wheel/sdist build:
+  1. Honor ``GOBBY_SKIP_UI_BUILD=1`` as an escape hatch (CI/contributors without npm).
+  2. If ``web/`` has ``package.json`` and ``npm`` is on PATH, run
+     ``npm ci && npm run build`` in ``web/`` to produce ``web/dist/``.
+  3. Copy ``web/dist/`` into ``src/gobby/ui/web/dist/`` so the
+     ``ui/web/dist/**/*`` package-data glob picks the assets up.
+  4. If neither a fresh build nor a pre-staged ``src/gobby/ui/web/dist/``
+     is available, emit a warning - the wheel will install but the UI
+     will 404 (same as before this wrapper existed).
+
+Editable installs skip the UI build entirely; the dev workflow uses
+``gobby ui dev`` against ``web/`` directly.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess  # nosec B404
+from pathlib import Path
+from typing import Any
+
+from setuptools import build_meta as _orig
+
+logger = logging.getLogger(__name__)
+
+get_requires_for_build_wheel = _orig.get_requires_for_build_wheel
+get_requires_for_build_sdist = _orig.get_requires_for_build_sdist
+get_requires_for_build_editable = _orig.get_requires_for_build_editable
+prepare_metadata_for_build_wheel = _orig.prepare_metadata_for_build_wheel
+prepare_metadata_for_build_editable = _orig.prepare_metadata_for_build_editable
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WEB_SRC = _REPO_ROOT / "web"
+_DIST_SRC = _WEB_SRC / "dist"
+_WHEEL_DEST = _REPO_ROOT / "src" / "gobby" / "ui" / "web" / "dist"
+
+
+def _stage_ui() -> None:
+    if os.environ.get("GOBBY_SKIP_UI_BUILD") == "1":
+        logger.info("GOBBY_SKIP_UI_BUILD=1 - skipping UI build step")
+        return
+
+    have_source = (_WEB_SRC / "package.json").exists()
+    have_npm = shutil.which("npm") is not None
+
+    if have_source and have_npm:
+        logger.info("Building web UI in %s", _WEB_SRC)
+        subprocess.run(["npm", "ci"], cwd=_WEB_SRC, check=True)  # nosec B603 B607
+        subprocess.run(["npm", "run", "build"], cwd=_WEB_SRC, check=True)  # nosec B603 B607
+
+    if not _DIST_SRC.exists():
+        if _WHEEL_DEST.exists():
+            logger.info("web/dist not available; reusing pre-staged %s", _WHEEL_DEST)
+            return
+        logger.warning(
+            "web/dist not found and npm build not possible - wheel will not contain UI assets. "
+            "Set GOBBY_SKIP_UI_BUILD=1 to silence this warning."
+        )
+        return
+
+    if _WHEEL_DEST.exists():
+        shutil.rmtree(_WHEEL_DEST)
+    _WHEEL_DEST.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(_DIST_SRC, _WHEEL_DEST)
+    logger.info("Staged web UI assets at %s", _WHEEL_DEST)
+
+
+def build_wheel(
+    wheel_directory: str,
+    config_settings: dict[str, Any] | None = None,
+    metadata_directory: str | None = None,
+) -> str:
+    _stage_ui()
+    return str(_orig.build_wheel(wheel_directory, config_settings, metadata_directory))
+
+
+def build_sdist(
+    sdist_directory: str,
+    config_settings: dict[str, Any] | None = None,
+) -> str:
+    _stage_ui()
+    return str(_orig.build_sdist(sdist_directory, config_settings))
+
+
+def build_editable(
+    wheel_directory: str,
+    config_settings: dict[str, Any] | None = None,
+    metadata_directory: str | None = None,
+) -> str:
+    return str(_orig.build_editable(wheel_directory, config_settings, metadata_directory))

--- a/build_backend/__init__.py
+++ b/build_backend/__init__.py
@@ -3,14 +3,14 @@
 Wraps setuptools.build_meta to stage the web UI into the wheel.
 
 Before every wheel/sdist build:
-  1. Honor ``GOBBY_SKIP_UI_BUILD=1`` as an escape hatch (CI/contributors without npm).
+  1. Honor ``GOBBY_SKIP_UI_BUILD=1`` to skip npm, while still requiring staged
+     UI assets for wheel builds.
   2. If ``web/`` has ``package.json`` and ``npm`` is on PATH, run
      ``npm ci && npm run build`` in ``web/`` to produce ``web/dist/``.
   3. Copy ``web/dist/`` into ``src/gobby/ui/web/dist/`` so the
      ``ui/web/dist/**/*`` package-data glob picks the assets up.
-  4. If neither a fresh build nor a pre-staged ``src/gobby/ui/web/dist/``
-     is available, emit a warning - the wheel will install but the UI
-     will 404 (same as before this wrapper existed).
+  4. Verify built wheels contain ``gobby/ui/web/dist/index.html`` so release
+     artifacts cannot silently ship without the production UI.
 
 Editable installs skip the UI build entirely; the dev workflow uses
 ``gobby ui dev`` against ``web/`` directly.
@@ -22,6 +22,7 @@ import logging
 import os
 import shutil
 import subprocess  # nosec B404
+import zipfile
 from pathlib import Path
 from typing import Any
 
@@ -56,6 +57,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 _WEB_SRC = _REPO_ROOT / "web"
 _DIST_SRC = _WEB_SRC / "dist"
 _WHEEL_DEST = _REPO_ROOT / "src" / "gobby" / "ui" / "web" / "dist"
+_WHEEL_UI_INDEX = "gobby/ui/web/dist/index.html"
 
 
 def _stage_ui() -> None:
@@ -76,8 +78,7 @@ def _stage_ui() -> None:
             logger.info("web/dist not available; reusing pre-staged %s", _WHEEL_DEST)
             return
         logger.warning(
-            "web/dist not found and npm build not possible - wheel will not contain UI assets. "
-            "Set GOBBY_SKIP_UI_BUILD=1 to silence this warning."
+            "web/dist not found and npm build not possible - wheel UI asset verification will fail."
         )
         return
 
@@ -88,13 +89,26 @@ def _stage_ui() -> None:
     logger.info("Staged web UI assets at %s", _WHEEL_DEST)
 
 
+def _verify_wheel_contains_ui(wheel_path: Path) -> None:
+    with zipfile.ZipFile(wheel_path) as wheel:
+        if _WHEEL_UI_INDEX not in wheel.namelist():
+            raise RuntimeError(
+                f"Built wheel is missing {_WHEEL_UI_INDEX}; build web/dist before publishing."
+            )
+
+
 def build_wheel(
     wheel_directory: str,
     config_settings: dict[str, Any] | None = None,
     metadata_directory: str | None = None,
 ) -> str:
     _stage_ui()
-    return str(_orig().build_wheel(wheel_directory, config_settings, metadata_directory))
+    wheel_name = str(_orig().build_wheel(wheel_directory, config_settings, metadata_directory))
+    wheel_path = Path(wheel_name)
+    if not wheel_path.is_absolute():
+        wheel_path = Path(wheel_directory) / wheel_path
+    _verify_wheel_contains_ui(wheel_path)
+    return wheel_name
 
 
 def build_sdist(

--- a/build_backend/__init__.py
+++ b/build_backend/__init__.py
@@ -25,15 +25,31 @@ import subprocess  # nosec B404
 from pathlib import Path
 from typing import Any
 
-from setuptools import build_meta as _orig
-
 logger = logging.getLogger(__name__)
 
-get_requires_for_build_wheel = _orig.get_requires_for_build_wheel
-get_requires_for_build_sdist = _orig.get_requires_for_build_sdist
-get_requires_for_build_editable = _orig.get_requires_for_build_editable
-prepare_metadata_for_build_wheel = _orig.prepare_metadata_for_build_wheel
-prepare_metadata_for_build_editable = _orig.prepare_metadata_for_build_editable
+
+def _orig() -> Any:
+    """Lazy-import setuptools.build_meta.
+
+    Kept lazy so importing this module (e.g., from tests that only exercise
+    `_stage_ui`) does not require setuptools to be installed at runtime.
+    """
+    from setuptools import build_meta
+
+    return build_meta
+
+
+def __getattr__(name: str) -> Any:
+    """Forward PEP 517 hook attributes to setuptools.build_meta on first access."""
+    if name in {
+        "get_requires_for_build_wheel",
+        "get_requires_for_build_sdist",
+        "get_requires_for_build_editable",
+        "prepare_metadata_for_build_wheel",
+        "prepare_metadata_for_build_editable",
+    }:
+        return getattr(_orig(), name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -78,7 +94,7 @@ def build_wheel(
     metadata_directory: str | None = None,
 ) -> str:
     _stage_ui()
-    return str(_orig.build_wheel(wheel_directory, config_settings, metadata_directory))
+    return str(_orig().build_wheel(wheel_directory, config_settings, metadata_directory))
 
 
 def build_sdist(
@@ -86,7 +102,7 @@ def build_sdist(
     config_settings: dict[str, Any] | None = None,
 ) -> str:
     _stage_ui()
-    return str(_orig.build_sdist(sdist_directory, config_settings))
+    return str(_orig().build_sdist(sdist_directory, config_settings))
 
 
 def build_editable(
@@ -94,4 +110,4 @@ def build_editable(
     config_settings: dict[str, Any] | None = None,
     metadata_directory: str | None = None,
 ) -> str:
-    return str(_orig.build_editable(wheel_directory, config_settings, metadata_directory))
+    return str(_orig().build_editable(wheel_directory, config_settings, metadata_directory))

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -227,6 +227,24 @@ embeddings:
   api_base: null
   api_key: null
 
+`gobby install` accepts `--embedding-url`, `--embedding-model`, and
+`--embedding-dim` to override the bundled provider defaults. When
+`--embedding-dim` is omitted alongside a custom URL or model, the installer
+probes `/v1/embeddings` on the target endpoint to detect the dim. The setup
+wizard exposes the same three knobs interactively.
+
+The default is `nomic-embed-text-v1.5@f16` (768-dim, ~137M params) — a safe
+choice for any local hardware. For users with capable local hardware,
+`Qwen3-Embedding-4B` (2560-dim, 4B params) is recommended: it is significantly
+stronger on MTEB and instruction-aware. Tradeoffs: roughly 3.3× the vector
+storage and a slower embed step. Example install:
+
+```bash
+gobby install --embedding-url http://localhost:1234/v1 \
+              --embedding-model text-embedding-qwen3-embedding-4b
+# --embedding-dim is auto-detected from the endpoint; pass 2560 to skip the probe.
+```
+
 memory:
   enabled: true
   backend: local

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -19,7 +19,7 @@ flowchart TB
 | --- | --- | --- |
 | `~/.gobby/bootstrap.yaml` | Machine | Startup values needed before SQLite is open |
 | `config_store` table in `~/.gobby/gobby-hub.db` | Machine | Runtime daemon settings and user overrides |
-| `~/.gobby/.mcp.json` | Machine | Persistent downstream MCP server registry |
+| `~/.gobby/mcp-servers.json` | Machine | Persistent downstream MCP server registry |
 | `.gobby/project.json` | Project | Project identity, verification commands, and project hook settings |
 | `~/.gobby/build.yaml` | Machine | Build lifecycle defaults |
 | `<project>/.gobby/build.yaml` | Project | Build lifecycle defaults for one repository |
@@ -374,7 +374,7 @@ entries with policy values `auto`, `approve_once`, or `always_ask`.
 
 ## MCP Server Registry
 
-Downstream MCP servers are stored in `~/.gobby/.mcp.json` and synchronized into
+Downstream MCP servers are stored in `~/.gobby/mcp-servers.json` and synchronized into
 daemon state by the MCP manager. The file has a top-level `servers` array:
 
 ```json
@@ -516,7 +516,7 @@ secret-like key.
 
 ### MCP Server Does Not Connect
 
-Check `~/.gobby/.mcp.json` for the server entry, transport-specific fields, and
+Check `~/.gobby/mcp-servers.json` for the server entry, transport-specific fields, and
 `enabled: true`. For generated or imported servers, refresh the MCP registry
 after changing server definitions.
 

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -32,8 +32,8 @@ curl -sS http://localhost:60887/api/admin/status
 Open dashboard and traces:
 
 ```text
-http://localhost:60889/#dashboard
-http://localhost:60889/#traces
+http://localhost:60887/#dashboard
+http://localhost:60887/#traces
 ```
 
 Fetch Prometheus metrics:

--- a/docs/guides/providers-and-models.md
+++ b/docs/guides/providers-and-models.md
@@ -35,7 +35,7 @@ curl -sS http://localhost:60887/api/providers/models
 Open web chat and use the provider/model controls:
 
 ```text
-http://localhost:60889/#chat
+http://localhost:60887/#chat
 ```
 
 Inspect configured defaults in the Gobby configuration files and through the

--- a/docs/guides/system-requirements.md
+++ b/docs/guides/system-requirements.md
@@ -11,7 +11,7 @@ Use this guide to decide what has to be installed before running Gobby 0.4.0.
 | Setup | Required | Good default |
 |-------|----------|--------------|
 | Daemon only | Python 3.13+, `uv`, 1 GB free disk, localhost ports 60887 and 60888 | 4+ CPU cores, 8 GB RAM |
-| Daemon + web UI | Daemon requirements plus localhost port 60889 | 8 GB RAM |
+| Daemon + web UI | Daemon requirements; installed UI is served on port 60887 | 8 GB RAM |
 | Full local search stack | Docker with Compose v2, Qdrant, Neo4j, embedding endpoint | 16 GB RAM minimum, 32 GB RAM preferred, SSD/NVMe storage |
 | Local embedding model | LM Studio with `lms` or Ollama with `ollama` | 16 GB RAM, GPU or unified memory when also running a chat model |
 
@@ -53,7 +53,8 @@ server, and optional UI dev server.
 | Database | `~/.gobby/gobby-hub.db` by default |
 | HTTP API | `localhost:60887` by default |
 | WebSocket | `localhost:60888` by default |
-| Web UI | `localhost:60889` by default |
+| Installed Web UI | `localhost:60887` by default |
+| Dev Web UI | `localhost:60889` when `gobby ui dev` is running |
 | Bind host | `localhost` by default |
 | Disk | 1 GB for code/dependencies plus SQLite database and transcript growth |
 | RAM | Hundreds of MB idle; plan 1-2 GB when many sessions, hooks, or MCP calls are active |
@@ -134,9 +135,9 @@ Default ports are chosen to avoid common development-server conflicts.
 
 | Port | Owner |
 |------|-------|
-| 60887 | Gobby HTTP API |
+| 60887 | Gobby HTTP API and installed web UI |
 | 60888 | Gobby WebSocket server |
-| 60889 | Gobby web UI |
+| 60889 | Gobby dev web UI |
 | 6333 | Qdrant HTTP |
 | 6334 | Qdrant gRPC |
 | 8474 | Neo4j HTTP, mapped from container port 7474 |

--- a/docs/guides/web-ui.md
+++ b/docs/guides/web-ui.md
@@ -6,11 +6,11 @@ configuration pages, and the operational dashboard.
 
 ## Mental Model
 
-Gobby runs the React app from `web/` beside the daemon HTTP and WebSocket
-services. In the default local development layout:
+Production installs serve the built React app from the daemon HTTP port. The
+frontend development server uses a separate port when `gobby ui dev` is running.
 
-- Web UI: `http://localhost:60889`
-- HTTP API: `http://localhost:60887`
+- Installed Web UI and HTTP API: `http://localhost:60887`
+- Dev Web UI: `http://localhost:60889`
 - WebSocket API: `ws://localhost:60888`
 - Tailscale UI URL, when enabled: shown by `gobby status`
 
@@ -40,7 +40,7 @@ uv run gobby status
 Open the web app:
 
 ```text
-http://localhost:60889/#chat
+http://localhost:60887/#chat
 ```
 
 Check the backend directly when the UI appears disconnected:
@@ -145,9 +145,9 @@ service health.
 
 ## HTTP
 
-The browser normally calls the web origin on `:60889`; the web server proxies
-API routes to the daemon services. Direct API debugging can use the HTTP daemon
-port from `gobby status`.
+The installed browser app normally calls the daemon origin on `:60887`. During
+frontend development, the `:60889` dev server proxies API routes to the daemon
+services. Direct API debugging can use the HTTP daemon port from `gobby status`.
 
 Useful checks:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,8 @@ override-dependencies = [
 
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]
-build-backend = "setuptools.build_meta"
+build-backend = "build_backend"
+backend-path = ["."]
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -125,6 +126,7 @@ gobby = [
     "install/shared/**/*",
     "storage/*.sql",
     "data/*",
+    "ui/web/dist/**/*",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gobby"
-version = "0.4.1"
+version = "0.4.2"
 description = "The bottleneck in AI coding isn't the model: It's the babysitting. Gobby is a local daemon that turns a task into a PR across Claude Code, Codex, Gemini, Qwen, and Droid. Stage dispatch, hook-time rules, progressive MCP proxy, and more. Gobby built Gobby."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/gobby/__init__.py
+++ b/src/gobby/__init__.py
@@ -6,4 +6,4 @@ with dependencies, validation, and TDD expansion. Agent spawning and worktree
 orchestration. Persistent memory, extensible workflows, and hooks.
 """
 
-__version__: str = "0.4.1"
+__version__: str = "0.4.2"

--- a/src/gobby/cli/__init__.py
+++ b/src/gobby/cli/__init__.py
@@ -4,8 +4,6 @@ Gobby CLI entry point.
 
 import click
 
-from gobby.config.app import load_config
-
 from .agents import agents
 from .auth import auth
 from .build import build_command
@@ -40,6 +38,7 @@ from .tasks import tasks
 from .test_quality import test_quality
 from .tokens import tokens
 from .ui import ui
+from .utils import load_full_config_from_db
 from .workflows import workflows
 from .worktrees import worktrees
 
@@ -53,9 +52,8 @@ from .worktrees import worktrees
 @click.pass_context
 def cli(ctx: click.Context, config: str | None) -> None:
     """Gobby - Local-first daemon for AI coding assistants."""
-    # Store config in context for subcommands
     ctx.ensure_object(dict)
-    ctx.obj["config"] = load_config(config)
+    ctx.obj["config"] = load_full_config_from_db(config)
 
 
 # Register commands

--- a/src/gobby/cli/_install_prompts.py
+++ b/src/gobby/cli/_install_prompts.py
@@ -19,6 +19,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _infer_embedding_provider_from_url(api_base: str) -> str:
+    """Infer the compatible local provider path for a custom OpenAI-style endpoint."""
+    return "ollama" if ":11434" in api_base else "lmstudio"
+
+
 @contextmanager
 def _ensure_db_and_secrets(
     db: LocalDatabase | None,
@@ -497,7 +502,10 @@ def _run_embedding_install(
         # No local providers; default to "none" to avoid unexpected cloud calls
         default_idx = len(options)  # points at "none"
 
-    if no_interactive:
+    if api_base_override is not None:
+        provider = _infer_embedding_provider_from_url(api_base_override)
+        click.echo(f"Using custom embedding endpoint ({provider}-compatible): {api_base_override}")
+    elif no_interactive:
         # Auto-select best available local provider; skip if none
         if lmstudio_ok:
             provider = "lmstudio"

--- a/src/gobby/cli/_install_prompts.py
+++ b/src/gobby/cli/_install_prompts.py
@@ -450,6 +450,10 @@ def _run_embedding_install(
     installer: Callable[..., dict[str, Any]],
     results: dict[str, dict[str, Any]],
     no_interactive: bool = False,
+    *,
+    api_base_override: str | None = None,
+    model_override: str | None = None,
+    dim_override: int | None = None,
 ) -> str:
     """Interactive embedding provider setup.
 
@@ -461,6 +465,10 @@ def _run_embedding_install(
         installer: The install_embedding function
         results: Results dict to accumulate install outcomes
         no_interactive: If True, auto-select best local provider without prompting
+        api_base_override: Override the provider's default API base URL.
+        model_override: Override the provider's default model id.
+        dim_override: Override the embedding dim. Triggers a probe when omitted
+            and either ``api_base_override`` or ``model_override`` is set.
 
     Returns:
         The provider name chosen: "lmstudio" | "ollama" | "openai" | "none"
@@ -567,6 +575,49 @@ def _run_embedding_install(
                 return "none"
             openai_api_key = openai_api_key.strip()
 
+    # Allow the user to override URL/model/dim interactively when no CLI flag
+    # was passed. Skip in no_interactive mode and for the "none" provider.
+    cli_overrides_supplied = (
+        api_base_override is not None or model_override is not None or dim_override is not None
+    )
+    if not no_interactive and not cli_overrides_supplied and provider != "none":
+        try:
+            customize = click.confirm(
+                "Customize endpoint URL, model id, or embedding dim?", default=False
+            )
+        except (click.Abort, EOFError):
+            click.echo("")
+            customize = False
+        if customize:
+            try:
+                url_input = click.prompt(
+                    "  API base URL (blank = provider default)",
+                    default="",
+                    show_default=False,
+                ).strip()
+                if url_input:
+                    api_base_override = url_input
+                model_input = click.prompt(
+                    "  Model id (blank = provider default)",
+                    default="",
+                    show_default=False,
+                ).strip()
+                if model_input:
+                    model_override = model_input
+                dim_input = click.prompt(
+                    "  Embedding dim (blank = auto-detect)",
+                    default="",
+                    show_default=False,
+                ).strip()
+                if dim_input:
+                    try:
+                        dim_override = int(dim_input)
+                    except ValueError:
+                        click.echo(f"  Invalid dim '{dim_input}'; will auto-detect")
+            except (click.Abort, EOFError):
+                click.echo("")
+                click.echo("Skipping custom overrides — using provider defaults.")
+
     # Run the installer
     click.echo("")
     if provider == "lmstudio":
@@ -576,7 +627,13 @@ def _run_embedding_install(
     elif provider == "openai":
         click.echo("Configuring OpenAI embeddings...")
 
-    result = installer(provider=provider, openai_api_key=openai_api_key)
+    result = installer(
+        provider=provider,
+        openai_api_key=openai_api_key,
+        model_override=model_override,
+        api_base_override=api_base_override,
+        dim_override=dim_override,
+    )
     results["embedding"] = result
 
     if result["success"]:

--- a/src/gobby/cli/install.py
+++ b/src/gobby/cli/install.py
@@ -150,6 +150,25 @@ __all__ = [
     help="Install voice chat dependencies (STT + TTS with voice cloning)",
 )
 @click.option(
+    "--embedding-url",
+    "embedding_url",
+    default=None,
+    help="Override the embedding provider's API base URL (e.g. for LM Studio on a LAN IP)",
+)
+@click.option(
+    "--embedding-model",
+    "embedding_model",
+    default=None,
+    help="Override the embedding model id (e.g. text-embedding-qwen3-embedding-4b)",
+)
+@click.option(
+    "--embedding-dim",
+    "embedding_dim",
+    type=int,
+    default=None,
+    help="Override the embedding dimension. Omit to auto-detect via /v1/embeddings probe.",
+)
+@click.option(
     "--no-interactive",
     "no_interactive_flag",
     is_flag=True,
@@ -175,6 +194,9 @@ def install(
     neo4j_password: str | None,
     voice_flag: bool,
     project_flag: bool,
+    embedding_url: str | None,
+    embedding_model: str | None,
+    embedding_dim: int | None,
     no_interactive_flag: bool,
     working_dir: Path | None,
 ) -> None:
@@ -316,7 +338,12 @@ def install(
         embedding_provider = "none"
         if is_full_install:
             embedding_provider = _run_embedding_install(
-                install_embedding, results, no_interactive=no_interactive_flag
+                install_embedding,
+                results,
+                no_interactive=no_interactive_flag,
+                api_base_override=embedding_url,
+                model_override=embedding_model,
+                dim_override=embedding_dim,
             )
 
         # Voice chat (optional — installs ~500MB of deps including PyTorch)

--- a/src/gobby/cli/installers/embedding.py
+++ b/src/gobby/cli/installers/embedding.py
@@ -94,12 +94,11 @@ def install_embedding(
         return {"success": False, "error": "OpenAI API key required for openai provider"}
 
     # Provider-specific setup: ensure model is downloaded and loaded.
-    # Skip the bundled setup when the user overrode the model — they're
-    # bringing their own (e.g. a Qwen3-Embedding GGUF served by LM Studio).
+    # Skip bundled local setup when the user points at their own model or endpoint.
     setup_result: dict[str, Any]
-    if provider == "lmstudio" and model_override is None:
+    if provider == "lmstudio" and model_override is None and api_base_override is None:
         setup_result = _setup_lmstudio()
-    elif provider == "ollama" and model_override is None:
+    elif provider == "ollama" and model_override is None and api_base_override is None:
         setup_result = _setup_ollama()
     else:
         setup_result = {"success": True}

--- a/src/gobby/cli/installers/embedding.py
+++ b/src/gobby/cli/installers/embedding.py
@@ -52,12 +52,21 @@ _OLLAMA_MODEL_NAME = "nomic-embed-text"
 def install_embedding(
     provider: str,
     openai_api_key: str | None = None,
+    *,
+    model_override: str | None = None,
+    api_base_override: str | None = None,
+    dim_override: int | None = None,
 ) -> dict[str, Any]:
     """Set up an embedding provider and persist config to config_store.
 
     Args:
         provider: One of "lmstudio", "ollama", "openai", "none"
         openai_api_key: Required when provider="openai"
+        model_override: Override the provider's default model id
+        api_base_override: Override the provider's default ``api_base`` URL
+        dim_override: Override the embedding dimension. When omitted and the
+            user supplied ``model_override`` or ``api_base_override``, the
+            installer probes ``/v1/embeddings`` to detect the dim automatically.
 
     Returns:
         Dict with success status and details:
@@ -84,22 +93,39 @@ def install_embedding(
     if provider == "openai" and not openai_api_key:
         return {"success": False, "error": "OpenAI API key required for openai provider"}
 
-    # Provider-specific setup: ensure model is downloaded and loaded
+    # Provider-specific setup: ensure model is downloaded and loaded.
+    # Skip the bundled setup when the user overrode the model — they're
+    # bringing their own (e.g. a Qwen3-Embedding GGUF served by LM Studio).
     setup_result: dict[str, Any]
-    if provider == "lmstudio":
+    if provider == "lmstudio" and model_override is None:
         setup_result = _setup_lmstudio()
-    elif provider == "ollama":
+    elif provider == "ollama" and model_override is None:
         setup_result = _setup_ollama()
-    else:  # openai
+    else:
         setup_result = {"success": True}
 
     if not setup_result["success"]:
         return setup_result
 
     cfg = _PROVIDER_CONFIG[provider]
-    model = cfg["model"]
-    api_base = cfg["api_base"]
-    dim = cfg["dim"]
+    model = model_override if model_override is not None else cfg["model"]
+    api_base = api_base_override if api_base_override is not None else cfg["api_base"]
+
+    if dim_override is not None:
+        dim = dim_override
+    elif model_override is not None or api_base_override is not None:
+        probed = _probe_embedding_dim(model=model, api_base=api_base, api_key=openai_api_key)
+        if probed is None:
+            return {
+                "success": False,
+                "error": (
+                    f"Could not probe embedding dim from {api_base or 'default endpoint'} "
+                    f"for model {model}. Pass --embedding-dim explicitly."
+                ),
+            }
+        dim = probed
+    else:
+        dim = cfg["dim"]
 
     # Health check before persisting
     health_ok = _health_check_embedding(
@@ -326,6 +352,41 @@ def _persist_embedding_config(
                 category="llm",
                 description="OpenAI API key for embeddings (set by gobby install)",
             )
+
+
+def _probe_embedding_dim(
+    model: str,
+    api_base: str | None,
+    api_key: str | None = None,
+) -> int | None:
+    """Send a 1-token probe and return ``len(embedding)``, or ``None`` on error.
+
+    Used to auto-detect the dim when the user supplied a custom model or
+    endpoint without passing ``--embedding-dim``.
+    """
+    from gobby.search.embeddings import generate_embedding
+
+    async def _probe() -> int | None:
+        try:
+            result = await generate_embedding(
+                "x",
+                model=model,
+                api_base=api_base,
+                api_key=api_key,
+                max_retries=1,
+            )
+            return len(result) if result else None
+        except Exception as e:
+            logger.warning(f"Embedding dim probe failed: {e}")
+            return None
+
+    try:
+        return asyncio.run(_probe())
+    except RuntimeError as e:
+        if "cannot be called from a running event loop" in str(e):
+            logger.warning("Cannot run dim probe: already in event loop")
+            return None
+        raise
 
 
 def _health_check_embedding(

--- a/src/gobby/cli/installers/mcp_config.py
+++ b/src/gobby/cli/installers/mcp_config.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from shutil import copy2
 from typing import Any, cast
 
+from gobby.config.mcp import DEFAULT_MCP_CONFIG_PATH, migrate_legacy_mcp_config
 from gobby.mcp_proxy.bundled import DEFAULT_EXTERNAL_MCP_SERVERS
 
 logger = logging.getLogger(__name__)
@@ -648,7 +649,7 @@ DEFAULT_MCP_SERVERS = DEFAULT_EXTERNAL_MCP_SERVERS
 
 
 def install_default_mcp_servers() -> dict[str, Any]:
-    """Install default external MCP servers to ~/.gobby/.mcp.json.
+    """Install default external MCP servers to ~/.gobby/mcp-servers.json.
 
     Adds bundled external MCP servers if not already configured. Also syncs to
     the database so the daemon proxy can serve them. These servers pull API
@@ -664,7 +665,8 @@ def install_default_mcp_servers() -> dict[str, Any]:
         "error": None,
     }
 
-    mcp_config_path = Path("~/.gobby/.mcp.json").expanduser()
+    migrate_legacy_mcp_config()
+    mcp_config_path = Path(DEFAULT_MCP_CONFIG_PATH).expanduser()
 
     # Ensure parent directory exists
     mcp_config_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/gobby/cli/ui.py
+++ b/src/gobby/cli/ui.py
@@ -11,8 +11,11 @@ import click
 
 from .utils import find_web_dir, get_gobby_home, spawn_ui_server, stop_ui_server
 
-# Path to web UI directory (legacy fallback)
-WEB_UI_DIR = Path(__file__).parent.parent / "ui" / "web"
+
+def _resolve_source_web_dir(ctx: click.Context | None) -> Path | None:
+    """Locate the web/ source tree (with package.json) for npm dev/build."""
+    config = ctx.obj.get("config") if ctx is not None and ctx.obj else None
+    return find_web_dir(config, require_source=True)
 
 
 def _get_ui_pid() -> int | None:
@@ -145,18 +148,19 @@ def ui_status(ctx: click.Context) -> None:
 @ui.command()
 @click.option("--port", "-p", default=60889, help="Dev server port")
 @click.option("--host", "-h", default="localhost", help="Dev server host")
-def dev(port: int, host: str) -> None:
+@click.pass_context
+def dev(ctx: click.Context, port: int, host: str) -> None:
     """Start the web UI development server with hot-reload (foreground)."""
-    if not WEB_UI_DIR.exists():
-        click.echo(f"Error: Web UI directory not found at {WEB_UI_DIR}", err=True)
+    web_dir = _resolve_source_web_dir(ctx)
+    if web_dir is None:
+        click.echo(
+            "Error: web/ source tree with package.json not found. "
+            "Run from a repo checkout or set ui.web_dir in config.",
+            err=True,
+        )
         sys.exit(1)
 
-    package_json = WEB_UI_DIR / "package.json"
-    if not package_json.exists():
-        click.echo(f"Error: package.json not found at {package_json}", err=True)
-        sys.exit(1)
-
-    if not _ensure_npm_deps_installed(WEB_UI_DIR):
+    if not _ensure_npm_deps_installed(web_dir):
         click.echo("Failed to install dependencies", err=True)
         sys.exit(1)
 
@@ -167,7 +171,7 @@ def dev(port: int, host: str) -> None:
     try:
         subprocess.run(  # nosec B603 B607
             ["npm", "run", "dev", "--", "--host", host, "--port", str(port)],
-            cwd=WEB_UI_DIR,
+            cwd=web_dir,
             check=True,
         )
     except KeyboardInterrupt:
@@ -178,25 +182,31 @@ def dev(port: int, host: str) -> None:
 
 
 @ui.command()
-def build() -> None:
+@click.pass_context
+def build(ctx: click.Context) -> None:
     """Build the web UI for production."""
-    if not WEB_UI_DIR.exists():
-        click.echo(f"Error: Web UI directory not found at {WEB_UI_DIR}", err=True)
+    web_dir = _resolve_source_web_dir(ctx)
+    if web_dir is None:
+        click.echo(
+            "Error: web/ source tree with package.json not found. "
+            "Run from a repo checkout or set ui.web_dir in config.",
+            err=True,
+        )
         sys.exit(1)
 
-    if not _ensure_npm_deps_installed(WEB_UI_DIR):
+    if not _ensure_npm_deps_installed(web_dir):
         click.echo("Failed to install dependencies", err=True)
         sys.exit(1)
 
     click.echo("Building web UI...")
     result = subprocess.run(  # nosec B603 B607
         ["npm", "run", "build"],
-        cwd=WEB_UI_DIR,
+        cwd=web_dir,
         capture_output=False,
     )
 
     if result.returncode == 0:
-        dist_dir = WEB_UI_DIR / "dist"
+        dist_dir = web_dir / "dist"
         click.echo(f"Build complete: {dist_dir}")
     else:
         click.echo("Build failed", err=True)
@@ -204,13 +214,19 @@ def build() -> None:
 
 
 @ui.command()
-def install_deps() -> None:
+@click.pass_context
+def install_deps(ctx: click.Context) -> None:
     """Install web UI dependencies."""
-    if not WEB_UI_DIR.exists():
-        click.echo(f"Error: Web UI directory not found at {WEB_UI_DIR}", err=True)
+    web_dir = _resolve_source_web_dir(ctx)
+    if web_dir is None:
+        click.echo(
+            "Error: web/ source tree with package.json not found. "
+            "Run from a repo checkout or set ui.web_dir in config.",
+            err=True,
+        )
         sys.exit(1)
 
-    if _ensure_npm_deps_installed(WEB_UI_DIR):
+    if _ensure_npm_deps_installed(web_dir):
         click.echo("Dependencies installed")
     else:
         click.echo("Failed to install dependencies", err=True)

--- a/src/gobby/cli/utils.py
+++ b/src/gobby/cli/utils.py
@@ -20,25 +20,28 @@ from gobby.utils.project_context import get_project_context
 logger = logging.getLogger(__name__)
 
 
-def load_full_config_from_db() -> DaemonConfig:
+def load_full_config_from_db(config_file: str | None = None) -> DaemonConfig:
     """Load full DaemonConfig from DB config_store + Pydantic defaults.
 
     Opens the database directly (using bootstrap.yaml for db_path),
     creates a ConfigStore, and calls load_config with it. Use this
     when CLI commands need the full config without a running daemon.
 
+    Args:
+        config_file: Optional path to a YAML config file. When provided, its
+            contents layer between bootstrap defaults and DB overrides
+            (DB still wins), matching the daemon's resolution order.
+
     Returns:
-        Fully resolved DaemonConfig
+        Fully resolved DaemonConfig (DB > config file > bootstrap > defaults).
     """
     from gobby.storage.config_store import ConfigStore
     from gobby.storage.secrets import SecretStore
 
-    # Phase 1: bootstrap gives us the database path
-    bootstrap_config = load_config()
+    bootstrap_config = load_config(config_file)
     db_path = Path(bootstrap_config.database_path).expanduser()
 
     if not db_path.exists():
-        # No DB yet — return bootstrap-only config
         return bootstrap_config
 
     db = LocalDatabase(db_path)
@@ -46,6 +49,7 @@ def load_full_config_from_db() -> DaemonConfig:
         config_store = ConfigStore(db)
         secret_store = SecretStore(db)
         return load_config(
+            config_file=config_file,
             config_store=config_store,
             secret_resolver=secret_store.get,
         )
@@ -475,37 +479,53 @@ def _is_process_alive(pid: int) -> bool:
         return False
 
 
-def find_web_dir(config: DaemonConfig | None = None) -> Path | None:
+def find_web_dir(
+    config: DaemonConfig | None = None, *, require_source: bool = False
+) -> Path | None:
     """Find the web UI directory.
 
+    A directory qualifies if it contains either:
+      - ``package.json`` (source/dev mode for ``gobby ui dev`` / ``ui build``), OR
+      - ``dist/index.html`` (installed-from-wheel mode for production serving).
+
     Search order:
-    1. config.ui.web_dir if set
-    2. cwd / web/ (has package.json)
-    3. Relative to gobby package (src/gobby/ui/web/)
+      1. ``config.ui.web_dir`` if set
+      2. ``cwd / web/``
+      3. Relative to gobby package (``<gobby>/ui/web/``)
 
     Args:
-        config: DaemonConfig instance (optional)
+        config: DaemonConfig instance (optional).
+        require_source: When True, only accept directories with ``package.json``
+            (i.e., npm-driven dev/build workflows). Production daemon callers
+            should leave this False so dist-only wheel installs are accepted.
 
     Returns:
-        Path to web/ directory, or None if not found
+        Path to the web/ directory, or None if not found.
     """
-    # 1. Explicit config path
+
+    def _qualifies(p: Path) -> bool:
+        if not p.exists():
+            return False
+        if (p / "package.json").exists():
+            return True
+        if not require_source and (p / "dist" / "index.html").exists():
+            return True
+        return False
+
     if config and hasattr(config, "ui") and config.ui.web_dir:
         p = Path(config.ui.web_dir).expanduser()
-        if p.exists() and (p / "package.json").exists():
+        if _qualifies(p):
             return p
 
-    # 2. cwd / web/
     cwd_web = Path.cwd() / "web"
-    if cwd_web.exists() and (cwd_web / "package.json").exists():
+    if _qualifies(cwd_web):
         return cwd_web
 
-    # 3. Relative to gobby package
     try:
         import gobby
 
         pkg_web = Path(gobby.__file__).parent / "ui" / "web"
-        if pkg_web.exists() and (pkg_web / "package.json").exists():
+        if _qualifies(pkg_web):
             return pkg_web
     except ImportError:
         logger.debug("gobby package not importable, skipping package web dir")

--- a/src/gobby/config/mcp.py
+++ b/src/gobby/config/mcp.py
@@ -1,8 +1,13 @@
 """
 MCP Configuration Manager for persistent server configuration.
 
-Manages MCP server configurations stored in ~/.gobby/.mcp.json,
+Manages MCP server configurations stored in ~/.gobby/mcp-servers.json,
 providing thread-safe read/write operations with validation.
+
+The file lived at ``~/.gobby/.mcp.json`` historically; that filename collides
+with Claude Code's project-level ``.mcp.json`` schema (Claude Code's
+``/doctor`` walks the tree and tries to parse it with a different schema).
+``migrate_legacy_mcp_config()`` moves the old file in place on first access.
 """
 
 import json
@@ -13,14 +18,57 @@ from typing import Any
 from gobby.mcp_proxy.manager import MCPServerConfig
 from gobby.storage.projects import GLOBAL_PROJECT_ID
 
-__all__ = ["MCPConfigManager", "MCPServerConfig"]
+__all__ = [
+    "DEFAULT_MCP_CONFIG_PATH",
+    "LEGACY_MCP_CONFIG_PATH",
+    "MCPConfigManager",
+    "MCPServerConfig",
+    "migrate_legacy_mcp_config",
+]
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_MCP_CONFIG_PATH = "~/.gobby/mcp-servers.json"
+LEGACY_MCP_CONFIG_PATH = "~/.gobby/.mcp.json"
+
+
+def migrate_legacy_mcp_config(
+    new_path: str | Path = DEFAULT_MCP_CONFIG_PATH,
+    legacy_path: str | Path = LEGACY_MCP_CONFIG_PATH,
+) -> bool:
+    """Rename the legacy ``~/.gobby/.mcp.json`` to the new location.
+
+    Idempotent: returns ``True`` only when the legacy file existed and the new
+    file did not. If both exist we leave them alone (the new file wins) and
+    log a warning so the operator can clean up. If neither exists the call is
+    a no-op.
+    """
+    legacy = Path(legacy_path).expanduser()
+    new = Path(new_path).expanduser()
+
+    if not legacy.exists():
+        return False
+
+    if new.exists():
+        logger.warning(
+            "Both legacy MCP config %s and new %s exist; leaving legacy file in "
+            "place. Delete %s after confirming %s has the desired contents.",
+            legacy,
+            new,
+            legacy,
+            new,
+        )
+        return False
+
+    new.parent.mkdir(parents=True, exist_ok=True)
+    legacy.replace(new)
+    logger.info("Migrated MCP config %s -> %s", legacy, new)
+    return True
 
 
 class MCPConfigManager:
     """
-    Manages persistent MCP server configurations in ~/.gobby/.mcp.json.
+    Manages persistent MCP server configurations in ~/.gobby/mcp-servers.json.
 
     Provides thread-safe operations for reading, writing, adding, and removing
     MCP server configurations with automatic validation and file locking.
@@ -53,10 +101,11 @@ class MCPConfigManager:
         Initialize MCP configuration manager.
 
         Args:
-            config_path: Path to MCP config file (default: ~/.gobby/.mcp.json)
+            config_path: Path to MCP config file (default: ~/.gobby/mcp-servers.json)
         """
         if config_path is None:
-            config_path = "~/.gobby/.mcp.json"
+            migrate_legacy_mcp_config()
+            config_path = DEFAULT_MCP_CONFIG_PATH
 
         self.config_path = Path(config_path).expanduser()
 

--- a/src/gobby/runner_lifecycle.py
+++ b/src/gobby/runner_lifecycle.py
@@ -116,6 +116,7 @@ async def run_daemon(runner: GobbyRunner) -> None:
         )
 
         from gobby.cli.utils import get_gobby_home
+        from gobby.config.mcp import migrate_legacy_mcp_config
 
         pid_file = get_gobby_home() / "gobby.pid"
         try:
@@ -123,6 +124,11 @@ async def run_daemon(runner: GobbyRunner) -> None:
             logger.info(f"Wrote PID file: {pid_file} (PID {os.getpid()})")
         except OSError as e:
             logger.warning(f"Could not write PID file {pid_file}: {e}")
+
+        try:
+            migrate_legacy_mcp_config()
+        except OSError as e:
+            logger.warning(f"Failed to migrate legacy MCP config: {e}")
 
         uvicorn_drain_timeout = 15
         config = uvicorn.Config(

--- a/tests/cli/installers/test_embedding_installer.py
+++ b/tests/cli/installers/test_embedding_installer.py
@@ -139,6 +139,57 @@ class TestInstallEmbeddingOverrides:
 
     @patch("gobby.cli.installers.embedding._persist_embedding_config")
     @patch("gobby.cli.installers.embedding._health_check_embedding", return_value=True)
+    @patch("gobby.cli.installers.embedding._probe_embedding_dim", return_value=768)
+    @patch("gobby.cli.installers.embedding._setup_lmstudio")
+    def test_api_base_override_skips_setup_and_uses_default_model(
+        self,
+        mock_setup: MagicMock,
+        mock_probe: MagicMock,
+        mock_health: MagicMock,
+        mock_persist: MagicMock,
+    ) -> None:
+        result = install_embedding(
+            provider="lmstudio",
+            api_base_override="http://192.168.1.10:1234/v1",
+        )
+
+        assert result["success"] is True
+        assert result["model"] == "text-embedding-nomic-embed-text-v1.5@f16"
+        assert result["api_base"] == "http://192.168.1.10:1234/v1"
+        mock_setup.assert_not_called()
+        mock_probe.assert_called_once()
+        persisted = mock_persist.call_args.kwargs
+        assert persisted["model"] == "text-embedding-nomic-embed-text-v1.5@f16"
+        assert persisted["api_base"] == "http://192.168.1.10:1234/v1"
+
+    @patch("gobby.cli.installers.embedding._persist_embedding_config")
+    @patch("gobby.cli.installers.embedding._health_check_embedding", return_value=True)
+    @patch("gobby.cli.installers.embedding._probe_embedding_dim", return_value=2560)
+    @patch("gobby.cli.installers.embedding._setup_lmstudio")
+    def test_api_base_and_model_overrides_skip_setup_and_persist_values(
+        self,
+        mock_setup: MagicMock,
+        mock_probe: MagicMock,
+        mock_health: MagicMock,
+        mock_persist: MagicMock,
+    ) -> None:
+        result = install_embedding(
+            provider="lmstudio",
+            model_override="text-embedding-qwen3-embedding-4b",
+            api_base_override="http://192.168.1.10:1234/v1",
+        )
+
+        assert result["success"] is True
+        assert result["model"] == "text-embedding-qwen3-embedding-4b"
+        assert result["dim"] == 2560
+        mock_setup.assert_not_called()
+        mock_probe.assert_called_once()
+        persisted = mock_persist.call_args.kwargs
+        assert persisted["model"] == "text-embedding-qwen3-embedding-4b"
+        assert persisted["api_base"] == "http://192.168.1.10:1234/v1"
+
+    @patch("gobby.cli.installers.embedding._persist_embedding_config")
+    @patch("gobby.cli.installers.embedding._health_check_embedding", return_value=True)
     @patch("gobby.cli.installers.embedding._probe_embedding_dim", return_value=2560)
     @patch("gobby.cli.installers.embedding._setup_lmstudio")
     def test_auto_detect_dim_via_probe(

--- a/tests/cli/installers/test_embedding_installer.py
+++ b/tests/cli/installers/test_embedding_installer.py
@@ -111,6 +111,91 @@ class TestInstallEmbedding:
         assert call_kwargs["openai_api_key"] == "sk-abc"
 
 
+class TestInstallEmbeddingOverrides:
+    """Override behavior for --embedding-url / --embedding-model / --embedding-dim."""
+
+    @patch("gobby.cli.installers.embedding._persist_embedding_config")
+    @patch("gobby.cli.installers.embedding._health_check_embedding", return_value=True)
+    @patch("gobby.cli.installers.embedding._setup_lmstudio")
+    def test_explicit_overrides_skip_setup_and_persist(
+        self, mock_setup: MagicMock, mock_health: MagicMock, mock_persist: MagicMock
+    ) -> None:
+        result = install_embedding(
+            provider="lmstudio",
+            model_override="text-embedding-qwen3-embedding-4b",
+            api_base_override="http://192.168.1.10:1234/v1",
+            dim_override=2560,
+        )
+        assert result["success"] is True
+        assert result["model"] == "text-embedding-qwen3-embedding-4b"
+        assert result["api_base"] == "http://192.168.1.10:1234/v1"
+        assert result["dim"] == 2560
+        # Custom model means we trust the user — skip the bundled LMS setup.
+        mock_setup.assert_not_called()
+        persisted = mock_persist.call_args.kwargs
+        assert persisted["model"] == "text-embedding-qwen3-embedding-4b"
+        assert persisted["api_base"] == "http://192.168.1.10:1234/v1"
+        assert persisted["dim"] == 2560
+
+    @patch("gobby.cli.installers.embedding._persist_embedding_config")
+    @patch("gobby.cli.installers.embedding._health_check_embedding", return_value=True)
+    @patch("gobby.cli.installers.embedding._probe_embedding_dim", return_value=2560)
+    @patch("gobby.cli.installers.embedding._setup_lmstudio")
+    def test_auto_detect_dim_via_probe(
+        self,
+        mock_setup: MagicMock,
+        mock_probe: MagicMock,
+        mock_health: MagicMock,
+        mock_persist: MagicMock,
+    ) -> None:
+        result = install_embedding(
+            provider="lmstudio",
+            model_override="text-embedding-qwen3-embedding-4b",
+            api_base_override="http://192.168.1.10:1234/v1",
+        )
+        assert result["success"] is True
+        assert result["dim"] == 2560
+        mock_probe.assert_called_once()
+        probe_kwargs = mock_probe.call_args.kwargs
+        assert probe_kwargs["model"] == "text-embedding-qwen3-embedding-4b"
+        assert probe_kwargs["api_base"] == "http://192.168.1.10:1234/v1"
+
+    @patch("gobby.cli.installers.embedding._setup_lmstudio")
+    @patch("gobby.cli.installers.embedding._probe_embedding_dim", return_value=None)
+    def test_probe_failure_returns_actionable_error(
+        self, mock_probe: MagicMock, mock_setup: MagicMock
+    ) -> None:
+        result = install_embedding(
+            provider="lmstudio",
+            model_override="text-embedding-qwen3-embedding-4b",
+            api_base_override="http://offline.local:9999/v1",
+        )
+        assert result["success"] is False
+        assert "Could not probe embedding dim" in result["error"]
+        assert "--embedding-dim" in result["error"]
+
+    @patch("gobby.cli.installers.embedding._persist_embedding_config")
+    @patch("gobby.cli.installers.embedding._health_check_embedding", return_value=True)
+    @patch("gobby.cli.installers.embedding._probe_embedding_dim")
+    @patch("gobby.cli.installers.embedding._setup_lmstudio", return_value={"success": True})
+    def test_defaults_preserved_when_no_overrides(
+        self,
+        mock_setup: MagicMock,
+        mock_probe: MagicMock,
+        mock_health: MagicMock,
+        mock_persist: MagicMock,
+    ) -> None:
+        result = install_embedding(provider="lmstudio")
+        assert result["success"] is True
+        assert result["model"] == "text-embedding-nomic-embed-text-v1.5@f16"
+        assert result["api_base"] == "http://localhost:1234/v1"
+        assert result["dim"] == 768
+        # No probe call when defaults apply.
+        mock_probe.assert_not_called()
+        # Setup IS called when running on the bundled defaults.
+        mock_setup.assert_called_once()
+
+
 class TestSetupLMStudio:
     """Test LM Studio setup subprocess orchestration."""
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -234,7 +234,7 @@ class TestStatusCommand:
         return CliRunner()
 
     @patch("gobby.cli.daemon.get_service_status", return_value={"installed": False})
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     @patch("gobby.cli.daemon.get_gobby_home")
     def test_status_no_pid_file(
         self,
@@ -268,7 +268,7 @@ class TestInitCommand:
         return CliRunner()
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_new_project(
         self,
         mock_load_config: MagicMock,
@@ -294,7 +294,7 @@ class TestInitCommand:
             assert "test-uuid-123" in result.output
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_existing_project(
         self,
         mock_load_config: MagicMock,
@@ -331,7 +331,7 @@ class TestInstallCommand:
     @patch("gobby.cli.install._is_qwen_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
     @patch("gobby.cli.install._is_droid_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_no_clis_detected(
         self,
         mock_load_config: MagicMock,
@@ -367,7 +367,7 @@ class TestUninstallCommand:
         return CliRunner()
 
     @patch("gobby.cli.install.Path.home")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_uninstall_no_hooks_found(
         self,
         mock_load_config: MagicMock,

--- a/tests/cli/test_cli_daemon.py
+++ b/tests/cli/test_cli_daemon.py
@@ -114,7 +114,7 @@ class TestStartCommand:
     @patch(
         "gobby.cli.daemon.get_service_status", return_value={"installed": True, "platform": "macos"}
     )
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_start_via_service_waits_for_health(
         self,
         mock_load_config: MagicMock,
@@ -147,7 +147,7 @@ class TestStartCommand:
     @patch("gobby.cli.daemon.kill_all_gobby_daemons")
     @patch("gobby.cli.daemon.init_local_storage")
     @patch("gobby.cli.daemon.time.sleep")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_start_success(
         self,
         mock_load_config: MagicMock,
@@ -204,7 +204,7 @@ class TestStartCommand:
     @patch("gobby.cli.daemon.kill_all_gobby_daemons")
     @patch("gobby.cli.daemon.init_local_storage")
     @patch("gobby.cli.daemon.time.sleep")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_start_warns_when_no_agent_auth_env_detected(
         self,
         mock_load_config: MagicMock,
@@ -259,7 +259,7 @@ class TestStartCommand:
     @patch("gobby.cli.daemon.kill_all_gobby_daemons")
     @patch("gobby.cli.daemon.init_local_storage")
     @patch("gobby.cli.daemon.time.sleep")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_start_with_verbose_flag(
         self,
         mock_load_config: MagicMock,
@@ -307,7 +307,7 @@ class TestStartCommand:
             assert "--verbose" in cmd
 
     @patch("gobby.cli.daemon.init_local_storage")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_start_daemon_already_running(
         self,
         mock_load_config: MagicMock,
@@ -343,7 +343,7 @@ class TestStartCommand:
 
     @patch("gobby.cli.daemon.kill_all_gobby_daemons")
     @patch("gobby.cli.daemon.init_local_storage")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_start_removes_stale_pid_file(
         self,
         mock_load_config: MagicMock,
@@ -396,7 +396,7 @@ class TestStartCommand:
     @patch("gobby.cli.daemon.is_port_available")
     @patch("gobby.cli.daemon.kill_all_gobby_daemons")
     @patch("gobby.cli.daemon.init_local_storage")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_start_http_port_in_use_timeout(
         self,
         mock_load_config: MagicMock,
@@ -431,7 +431,7 @@ class TestStartCommand:
     @patch("gobby.cli.daemon.is_port_available")
     @patch("gobby.cli.daemon.kill_all_gobby_daemons")
     @patch("gobby.cli.daemon.init_local_storage")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_start_websocket_port_in_use_timeout(
         self,
         mock_load_config: MagicMock,
@@ -473,7 +473,7 @@ class TestStartCommand:
     @patch("gobby.cli.daemon.kill_all_gobby_daemons")
     @patch("gobby.cli.daemon.init_local_storage")
     @patch("gobby.cli.daemon.time.sleep")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_start_process_exits_immediately(
         self,
         mock_load_config: MagicMock,
@@ -517,7 +517,7 @@ class TestStartCommand:
     @patch("gobby.cli.daemon.kill_all_gobby_daemons")
     @patch("gobby.cli.daemon.init_local_storage")
     @patch("gobby.cli.daemon.time.sleep")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_start_health_check_fails(
         self,
         mock_load_config: MagicMock,
@@ -561,7 +561,7 @@ class TestStartCommand:
     @patch("gobby.cli.daemon.kill_all_gobby_daemons")
     @patch("gobby.cli.daemon.init_local_storage")
     @patch("gobby.cli.daemon.time.sleep")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_start_kills_existing_processes(
         self,
         mock_load_config: MagicMock,
@@ -621,7 +621,7 @@ class TestStopCommand:
 
     @patch("gobby.cli.daemon.get_service_status", return_value={"installed": False})
     @patch("gobby.cli.daemon.stop_daemon_util")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_stop_success(
         self,
         mock_load_config: MagicMock,
@@ -646,7 +646,7 @@ class TestStopCommand:
 
     @patch("gobby.cli.daemon.get_service_status", return_value={"installed": False})
     @patch("gobby.cli.daemon.stop_daemon_util")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_stop_failure(
         self,
         mock_load_config: MagicMock,
@@ -676,7 +676,7 @@ class TestStopCommand:
         return_value={"installed": True, "running": True, "platform": "macos", "pid": 4321},
     )
     @patch("gobby.cli.daemon.stop_daemon_util")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_stop_via_service_waits_for_shutdown(
         self,
         mock_load_config: MagicMock,
@@ -735,7 +735,7 @@ class TestRestartCommand:
     )
     @patch("gobby.cli.daemon.stop_daemon_util")
     @patch("gobby.cli.daemon.setup_logging")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_restart_via_service_waits_for_health(
         self,
         mock_load_config: MagicMock,
@@ -791,7 +791,7 @@ class TestRestartCommand:
     )
     @patch("gobby.cli.daemon.stop_daemon_util")
     @patch("gobby.cli.daemon.setup_logging")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_restart_via_service_fails_when_startup_readiness_does_not_complete(
         self,
         mock_load_config: MagicMock,
@@ -832,7 +832,7 @@ class TestRestartCommand:
     )
     @patch("gobby.cli.daemon.stop_daemon_util")
     @patch("gobby.cli.daemon.setup_logging")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_restart_via_service_fails_when_health_does_not_return(
         self,
         mock_load_config: MagicMock,
@@ -881,7 +881,7 @@ class TestRestartCommand:
     )
     @patch("gobby.cli.daemon.stop_daemon_util")
     @patch("gobby.cli.daemon.setup_logging")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_restart_via_service_fails_when_stop_does_not_complete(
         self,
         mock_load_config: MagicMock,
@@ -920,7 +920,7 @@ class TestRestartCommand:
     @patch("gobby.cli.daemon.stop_daemon_util")
     @patch("gobby.cli.daemon.setup_logging")
     @patch("gobby.cli.daemon.time.sleep")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_restart_success(
         self,
         mock_load_config: MagicMock,
@@ -1000,7 +1000,7 @@ class TestRestartCommand:
     @patch("gobby.cli.daemon.stop_daemon_util")
     @patch("gobby.cli.daemon.setup_logging")
     @patch("gobby.cli.daemon.time.sleep")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_restart_with_verbose(
         self,
         mock_load_config: MagicMock,
@@ -1066,7 +1066,7 @@ class TestStatusCommand:
 
     @patch("gobby.cli.daemon.get_service_status", return_value={"installed": False})
     @patch("gobby.cli.daemon.get_gobby_home")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_status_no_pid_file(
         self,
         mock_load_config: MagicMock,
@@ -1092,7 +1092,7 @@ class TestStatusCommand:
 
     @patch("gobby.cli.daemon.get_service_status", return_value={"installed": False})
     @patch("gobby.cli.daemon.get_gobby_home")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_status_invalid_pid_file(
         self,
         mock_load_config: MagicMock,
@@ -1120,7 +1120,7 @@ class TestStatusCommand:
             assert "Stopped" in result.output
 
     @patch("gobby.cli.daemon.get_gobby_home")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_status_stale_pid_file(
         self,
         mock_load_config: MagicMock,
@@ -1156,7 +1156,7 @@ class TestStatusCommand:
     @patch("gobby.cli.daemon.get_gobby_home")
     @patch("gobby.cli.daemon.fetch_rich_status")
     @patch("gobby.cli.daemon.psutil.Process")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_status_daemon_running(
         self,
         mock_load_config: MagicMock,
@@ -1201,7 +1201,7 @@ class TestStatusCommand:
     )
     @patch("gobby.cli.daemon.fetch_rich_status")
     @patch("gobby.cli.daemon.psutil.Process")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_status_psutil_error(
         self,
         mock_load_config: MagicMock,
@@ -1260,7 +1260,7 @@ class TestDaemonCommandsIntegration:
     @patch("gobby.cli.daemon.kill_all_gobby_daemons")
     @patch("gobby.cli.daemon.init_local_storage")
     @patch("gobby.cli.daemon.time.sleep")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_start_displays_startup_summary(
         self,
         mock_load_config: MagicMock,
@@ -1339,7 +1339,7 @@ class TestEdgeCases:
     @patch("gobby.cli.daemon.kill_all_gobby_daemons")
     @patch("gobby.cli.daemon.init_local_storage")
     @patch("gobby.cli.daemon.time.sleep")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_start_health_check_timeout(
         self,
         mock_load_config: MagicMock,
@@ -1390,7 +1390,7 @@ class TestEdgeCases:
     @patch("gobby.cli.daemon.kill_all_gobby_daemons")
     @patch("gobby.cli.daemon.init_local_storage")
     @patch("gobby.cli.daemon.time.sleep")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_start_health_check_non_200_response(
         self,
         mock_load_config: MagicMock,
@@ -1450,7 +1450,7 @@ class TestEdgeCases:
     @patch("gobby.cli.daemon.is_port_available")
     @patch("gobby.cli.daemon.kill_all_gobby_daemons")
     @patch("gobby.cli.daemon.init_local_storage")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_start_popen_exception(
         self,
         mock_load_config: MagicMock,
@@ -1489,7 +1489,7 @@ class TestEdgeCases:
     )
     @patch("gobby.cli.daemon.fetch_rich_status")
     @patch("gobby.cli.daemon.psutil.Process")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_status_with_rich_data(
         self,
         mock_load_config: MagicMock,
@@ -1564,7 +1564,7 @@ class TestCommandBuilding:
     @patch("gobby.cli.daemon.kill_all_gobby_daemons")
     @patch("gobby.cli.daemon.init_local_storage")
     @patch("gobby.cli.daemon.time.sleep")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_start_command_uses_correct_module(
         self,
         mock_load_config: MagicMock,
@@ -1620,7 +1620,7 @@ class TestCommandBuilding:
     @patch("gobby.cli.daemon.kill_all_gobby_daemons")
     @patch("gobby.cli.daemon.init_local_storage")
     @patch("gobby.cli.daemon.time.sleep")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_start_subprocess_options(
         self,
         mock_load_config: MagicMock,

--- a/tests/cli/test_cli_extensions.py
+++ b/tests/cli/test_cli_extensions.py
@@ -150,7 +150,7 @@ class TestHooksListCommand:
         assert result.exit_code == 0
         assert "List supported hook event types" in result.output
 
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_hooks_list_default_output(
         self,
         mock_load_config: MagicMock,
@@ -170,7 +170,7 @@ class TestHooksListCommand:
         assert "before_tool" in result.output
         assert "after_tool" in result.output
 
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_hooks_list_json_output(
         self,
         mock_load_config: MagicMock,
@@ -200,7 +200,7 @@ class TestHooksListCommand:
         assert "after_tool" in hook_names
         assert "stop" in hook_names
 
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_hooks_list_contains_descriptions(
         self,
         mock_load_config: MagicMock,
@@ -234,7 +234,7 @@ class TestHooksTestCommand:
     @patch("gobby.cli.extensions.call_mcp_api")
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_hooks_test_success(
         self,
         mock_load_config: MagicMock,
@@ -265,7 +265,7 @@ class TestHooksTestCommand:
     @patch("gobby.cli.extensions.call_mcp_api")
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_hooks_test_with_source_option(
         self,
         mock_load_config: MagicMock,
@@ -295,7 +295,7 @@ class TestHooksTestCommand:
     @patch("gobby.cli.extensions.call_mcp_api")
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_hooks_test_tool_event_adds_tool_name(
         self,
         mock_load_config: MagicMock,
@@ -325,7 +325,7 @@ class TestHooksTestCommand:
     @patch("gobby.cli.extensions.call_mcp_api")
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_hooks_test_non_tool_event_no_tool_name(
         self,
         mock_load_config: MagicMock,
@@ -355,7 +355,7 @@ class TestHooksTestCommand:
     @patch("gobby.cli.extensions.call_mcp_api")
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_hooks_test_json_output(
         self,
         mock_load_config: MagicMock,
@@ -387,7 +387,7 @@ class TestHooksTestCommand:
     @patch("gobby.cli.extensions.call_mcp_api")
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_hooks_test_with_inject_context(
         self,
         mock_load_config: MagicMock,
@@ -414,7 +414,7 @@ class TestHooksTestCommand:
 
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_hooks_test_daemon_not_running(
         self,
         mock_load_config: MagicMock,
@@ -436,7 +436,7 @@ class TestHooksTestCommand:
     @patch("gobby.cli.extensions.call_mcp_api")
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_hooks_test_api_failure(
         self,
         mock_load_config: MagicMock,
@@ -486,7 +486,7 @@ class TestWebhooksListCommand:
     @patch("gobby.cli.extensions.call_mcp_api")
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_webhooks_list_disabled(
         self,
         mock_load_config: MagicMock,
@@ -512,7 +512,7 @@ class TestWebhooksListCommand:
     @patch("gobby.cli.extensions.call_mcp_api")
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_webhooks_list_no_endpoints(
         self,
         mock_load_config: MagicMock,
@@ -539,7 +539,7 @@ class TestWebhooksListCommand:
     @patch("gobby.cli.extensions.call_mcp_api")
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_webhooks_list_with_endpoints(
         self,
         mock_load_config: MagicMock,
@@ -591,7 +591,7 @@ class TestWebhooksListCommand:
     @patch("gobby.cli.extensions.call_mcp_api")
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_webhooks_list_endpoint_no_url(
         self,
         mock_load_config: MagicMock,
@@ -624,7 +624,7 @@ class TestWebhooksListCommand:
     @patch("gobby.cli.extensions.call_mcp_api")
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_webhooks_list_json_output(
         self,
         mock_load_config: MagicMock,
@@ -659,7 +659,7 @@ class TestWebhooksListCommand:
 
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_webhooks_list_daemon_not_running(
         self,
         mock_load_config: MagicMock,
@@ -681,7 +681,7 @@ class TestWebhooksListCommand:
     @patch("gobby.cli.extensions.call_mcp_api")
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_webhooks_list_api_failure(
         self,
         mock_load_config: MagicMock,
@@ -717,7 +717,7 @@ class TestWebhooksTestCommand:
     @patch("gobby.cli.extensions.call_mcp_api")
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_webhooks_test_success(
         self,
         mock_load_config: MagicMock,
@@ -754,7 +754,7 @@ class TestWebhooksTestCommand:
     @patch("gobby.cli.extensions.call_mcp_api")
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_webhooks_test_with_event_option(
         self,
         mock_load_config: MagicMock,
@@ -783,7 +783,7 @@ class TestWebhooksTestCommand:
     @patch("gobby.cli.extensions.call_mcp_api")
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_webhooks_test_success_no_response_time(
         self,
         mock_load_config: MagicMock,
@@ -809,7 +809,7 @@ class TestWebhooksTestCommand:
     @patch("gobby.cli.extensions.call_mcp_api")
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_webhooks_test_failure(
         self,
         mock_load_config: MagicMock,
@@ -838,7 +838,7 @@ class TestWebhooksTestCommand:
     @patch("gobby.cli.extensions.call_mcp_api")
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_webhooks_test_failure_with_status_code(
         self,
         mock_load_config: MagicMock,
@@ -868,7 +868,7 @@ class TestWebhooksTestCommand:
     @patch("gobby.cli.extensions.call_mcp_api")
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_webhooks_test_failure_unknown_error(
         self,
         mock_load_config: MagicMock,
@@ -893,7 +893,7 @@ class TestWebhooksTestCommand:
     @patch("gobby.cli.extensions.call_mcp_api")
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_webhooks_test_json_output(
         self,
         mock_load_config: MagicMock,
@@ -924,7 +924,7 @@ class TestWebhooksTestCommand:
 
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_webhooks_test_daemon_not_running(
         self,
         mock_load_config: MagicMock,
@@ -946,7 +946,7 @@ class TestWebhooksTestCommand:
     @patch("gobby.cli.extensions.call_mcp_api")
     @patch("gobby.cli.extensions.check_daemon_running")
     @patch("gobby.cli.extensions.get_daemon_client")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_webhooks_test_api_failure(
         self,
         mock_load_config: MagicMock,

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -95,7 +95,7 @@ class TestInitNewProject:
     """Tests for initializing a new project."""
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_new_project_success(
         self,
         mock_load_config: MagicMock,
@@ -120,7 +120,7 @@ class TestInitNewProject:
         mock_initialize.assert_called_once()
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_with_custom_name(
         self,
         mock_load_config: MagicMock,
@@ -146,7 +146,7 @@ class TestInitNewProject:
         )
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_with_github_url(
         self,
         mock_load_config: MagicMock,
@@ -174,7 +174,7 @@ class TestInitNewProject:
         )
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_with_both_options(
         self,
         mock_load_config: MagicMock,
@@ -210,7 +210,7 @@ class TestInitNewProject:
 
     @patch("gobby.cli.init._maybe_run_linear_setup")
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_skips_linear_setup_by_default(
         self,
         mock_load_config: MagicMock,
@@ -238,7 +238,7 @@ class TestInitNewProject:
 
     @patch("gobby.cli.init._maybe_run_linear_setup")
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_linear_setup_option(
         self,
         mock_load_config: MagicMock,
@@ -279,7 +279,7 @@ class TestInitExistingProject:
     """Tests for initializing when a project already exists."""
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_existing_project(
         self,
         mock_load_config: MagicMock,
@@ -308,7 +308,7 @@ class TestInitWithVerification:
     """Tests for initialization with verification commands."""
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_shows_verification_commands(
         self,
         mock_load_config: MagicMock,
@@ -335,7 +335,7 @@ class TestInitWithVerification:
         assert "uv run ruff check src/" in result.output
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_shows_custom_verification_commands(
         self,
         mock_load_config: MagicMock,
@@ -358,7 +358,7 @@ class TestInitWithVerification:
         assert "uv run pytest tests/e2e/" in result.output
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_verification_skips_none_values(
         self,
         mock_load_config: MagicMock,
@@ -399,7 +399,7 @@ class TestInitWithVerification:
         assert "integration: None" not in result.output
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_no_verification_commands(
         self,
         mock_load_config: MagicMock,
@@ -420,7 +420,7 @@ class TestInitWithVerification:
         assert "Detected verification commands:" not in result.output
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_verification_empty_dict(
         self,
         mock_load_config: MagicMock,
@@ -452,7 +452,7 @@ class TestInitWithVerification:
         assert "Detected verification commands:" not in result.output
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_verification_custom_non_dict(
         self,
         mock_load_config: MagicMock,
@@ -492,7 +492,7 @@ class TestInitErrorHandling:
     """Tests for error handling in the init command."""
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_generic_exception(
         self,
         mock_load_config: MagicMock,
@@ -513,7 +513,7 @@ class TestInitErrorHandling:
         assert "Database connection failed" in result.output
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_permission_error(
         self,
         mock_load_config: MagicMock,
@@ -534,7 +534,7 @@ class TestInitErrorHandling:
         assert "Cannot write to directory" in result.output
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_file_not_found_error(
         self,
         mock_load_config: MagicMock,
@@ -555,7 +555,7 @@ class TestInitErrorHandling:
         assert "Config file not found" in result.output
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_os_error(
         self,
         mock_load_config: MagicMock,
@@ -576,7 +576,7 @@ class TestInitErrorHandling:
         assert "Disk full" in result.output
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_value_error(
         self,
         mock_load_config: MagicMock,
@@ -601,7 +601,7 @@ class TestInitOutputFormat:
     """Tests for the output format of the init command."""
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_output_format_new_project(
         self,
         mock_load_config: MagicMock,
@@ -638,7 +638,7 @@ class TestInitOutputFormat:
         assert config_line is not None
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_output_format_existing_project(
         self,
         mock_load_config: MagicMock,
@@ -675,7 +675,7 @@ class TestInitCwdHandling:
     """Tests for current working directory handling."""
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_uses_cwd(
         self,
         mock_load_config: MagicMock,
@@ -700,7 +700,7 @@ class TestInitCwdHandling:
         assert isinstance(cwd_arg, Path)
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_with_path_option(
         self,
         mock_load_config: MagicMock,
@@ -725,7 +725,7 @@ class TestInitCwdHandling:
         assert cwd_arg == target_dir.resolve()
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_with_long_path_option(
         self,
         mock_load_config: MagicMock,
@@ -759,7 +759,7 @@ class TestVerificationCommandsDataclass:
     """Tests for VerificationCommands dataclass behavior in CLI context."""
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_verification_with_all_fields(
         self,
         mock_load_config: MagicMock,
@@ -799,7 +799,7 @@ class TestVerificationCommandsDataclass:
         assert "security:" in result.output
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_verification_with_multiple_custom_commands(
         self,
         mock_load_config: MagicMock,
@@ -865,7 +865,7 @@ class TestInitContext:
     """Tests for Click context handling."""
 
     @patch("gobby.cli.init.initialize_project")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_init_receives_context(
         self,
         mock_load_config: MagicMock,

--- a/tests/cli/test_cli_install.py
+++ b/tests/cli/test_cli_install.py
@@ -213,7 +213,7 @@ class TestInstallCommand:
     @patch("gobby.cli.install._is_claude_code_installed")
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_no_clis_detected_no_git(
         self,
         mock_load_config: MagicMock,
@@ -245,7 +245,7 @@ class TestInstallCommand:
     @patch("gobby.cli.install._is_claude_code_installed")
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_claude_only_flag(
         self,
         mock_load_config: MagicMock,
@@ -284,7 +284,7 @@ class TestInstallCommand:
     @patch("gobby.cli.install._is_claude_code_installed")
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_gemini_only_flag(
         self,
         mock_load_config: MagicMock,
@@ -324,7 +324,7 @@ class TestInstallCommand:
 
     @patch("gobby.cli.install._ensure_daemon_config")
     @patch("gobby.cli.install.install_qwen")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_qwen_only_flag(
         self,
         mock_load_config: MagicMock,
@@ -357,7 +357,7 @@ class TestInstallCommand:
 
     @patch("gobby.cli.install._ensure_daemon_config")
     @patch("gobby.cli.install.install_droid")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_droid_only_flag(
         self,
         mock_load_config: MagicMock,
@@ -391,7 +391,7 @@ class TestInstallCommand:
     @patch("gobby.cli.install._is_claude_code_installed")
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_codex_only_flag_codex_detected(
         self,
         mock_load_config: MagicMock,
@@ -431,7 +431,7 @@ class TestInstallCommand:
     @patch("gobby.cli.install._is_claude_code_installed")
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_codex_only_flag_codex_not_detected(
         self,
         mock_load_config: MagicMock,
@@ -510,7 +510,7 @@ class TestInstallCommand:
     @patch("gobby.cli.install._is_claude_code_installed")
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_hooks_only_flag(
         self,
         mock_load_config: MagicMock,
@@ -547,7 +547,7 @@ class TestInstallCommand:
     @patch("gobby.cli.install._is_claude_code_installed")
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_hooks_with_skipped(
         self,
         mock_load_config: MagicMock,
@@ -582,7 +582,7 @@ class TestInstallCommand:
     @patch("gobby.cli.install._is_claude_code_installed")
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_hooks_failure(
         self,
         mock_load_config: MagicMock,
@@ -617,7 +617,7 @@ class TestInstallCommand:
     @patch("gobby.cli.install._is_claude_code_installed")
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_all_flag_auto_detect(
         self,
         mock_load_config: MagicMock,
@@ -675,7 +675,7 @@ class TestInstallCommand:
     @patch("gobby.cli.install._is_claude_code_installed")
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_default_acts_like_all(
         self,
         mock_load_config: MagicMock,
@@ -714,7 +714,7 @@ class TestInstallCommand:
     @patch("gobby.cli.install._is_claude_code_installed")
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_claude_failure(
         self,
         mock_load_config: MagicMock,
@@ -749,7 +749,7 @@ class TestInstallCommand:
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
     @patch("gobby.cli.install.get_install_dir")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_shows_dev_mode(
         self,
         mock_load_config: MagicMock,
@@ -786,7 +786,7 @@ class TestInstallCommand:
     @patch("gobby.cli.install._is_claude_code_installed")
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_shows_created_config(
         self,
         mock_load_config: MagicMock,
@@ -821,7 +821,7 @@ class TestInstallCommand:
     @patch("gobby.cli.install._is_claude_code_installed")
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_codex_config_already_configured(
         self,
         mock_load_config: MagicMock,
@@ -877,7 +877,7 @@ class TestUninstallCommand:
         assert "--all" in result.output
         assert "--yes" in result.output or "-y" in result.output
 
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_uninstall_no_hooks_found(
         self,
         mock_load_config: MagicMock,
@@ -899,7 +899,7 @@ class TestUninstallCommand:
         assert "No Gobby hooks found" in result.output
 
     @patch("gobby.cli.install.uninstall_claude")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_uninstall_claude_only_flag(
         self,
         mock_load_config: MagicMock,
@@ -930,7 +930,7 @@ class TestUninstallCommand:
         mock_uninstall_claude.assert_called_once()
 
     @patch("gobby.cli.install.uninstall_gemini")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_uninstall_gemini_only_flag(
         self,
         mock_load_config: MagicMock,
@@ -959,7 +959,7 @@ class TestUninstallCommand:
         mock_uninstall_gemini.assert_called_once()
 
     @patch("gobby.cli.install.uninstall_codex")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_uninstall_codex_only_flag(
         self,
         mock_load_config: MagicMock,
@@ -985,7 +985,7 @@ class TestUninstallCommand:
         mock_uninstall_codex.assert_called_once()
 
     @patch("gobby.cli.install.uninstall_qwen")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_uninstall_qwen_only_flag(
         self,
         mock_load_config: MagicMock,
@@ -1013,7 +1013,7 @@ class TestUninstallCommand:
         mock_uninstall_qwen.assert_called_once()
 
     @patch("gobby.cli.install.uninstall_droid")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_uninstall_droid_only_flag(
         self,
         mock_load_config: MagicMock,
@@ -1038,7 +1038,7 @@ class TestUninstallCommand:
         mock_uninstall_droid.assert_called_once()
 
     @patch("gobby.cli.install.uninstall_claude")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_uninstall_claude_failure(
         self,
         mock_load_config: MagicMock,
@@ -1064,7 +1064,7 @@ class TestUninstallCommand:
         assert "Some uninstallations failed" in result.output
 
     @patch("gobby.cli.install.uninstall_claude")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_uninstall_no_hooks_to_remove(
         self,
         mock_load_config: MagicMock,
@@ -1088,7 +1088,7 @@ class TestUninstallCommand:
         assert "(no hooks found to remove)" in result.output
 
     @patch("gobby.cli.install.uninstall_codex")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_uninstall_codex_no_integration_found(
         self,
         mock_load_config: MagicMock,
@@ -1114,7 +1114,7 @@ class TestUninstallCommand:
     @patch("gobby.cli.install.uninstall_codex")
     @patch("gobby.cli.install.uninstall_claude")
     @patch("gobby.cli.install.uninstall_gemini")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_uninstall_all_auto_detect(
         self,
         mock_load_config: MagicMock,
@@ -1163,7 +1163,7 @@ class TestUninstallCommand:
         mock_uninstall_claude.assert_called_once()
         mock_uninstall_gemini.assert_called_once()
 
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_uninstall_requires_confirmation(
         self,
         mock_load_config: MagicMock,
@@ -1185,7 +1185,7 @@ class TestUninstallCommand:
         assert "Aborted" in result.output
 
     @patch("gobby.cli.install.uninstall_claude")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_uninstall_confirms_with_yes_input(
         self,
         mock_load_config: MagicMock,
@@ -1214,7 +1214,7 @@ class TestUninstallCommand:
     @patch("gobby.cli.install.uninstall_codex")
     @patch("gobby.cli.install.uninstall_claude")
     @patch("gobby.cli.install.uninstall_gemini")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_uninstall_default_acts_like_all(
         self,
         mock_load_config: MagicMock,
@@ -1348,7 +1348,7 @@ class TestInstallEdgeCases:
     @patch("gobby.cli.install._is_claude_code_installed")
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_multiple_flags(
         self,
         mock_load_config: MagicMock,
@@ -1395,7 +1395,7 @@ class TestInstallEdgeCases:
     @patch("gobby.cli.install._is_claude_code_installed")
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_cli_and_hooks_together(
         self,
         mock_load_config: MagicMock,
@@ -1439,7 +1439,7 @@ class TestInstallEdgeCases:
     @patch("gobby.cli.install._is_claude_code_installed")
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_hooks_empty_result(
         self,
         mock_load_config: MagicMock,
@@ -1477,7 +1477,7 @@ class TestUninstallEdgeCases:
         return CliRunner()
 
     @patch("gobby.cli.install.uninstall_codex")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_uninstall_codex_checks_home_path(
         self,
         mock_load_config: MagicMock,
@@ -1513,7 +1513,7 @@ class TestUninstallEdgeCases:
         mock_uninstall_codex.assert_called_once()
 
     @patch("gobby.cli.install.uninstall_gemini")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_uninstall_gemini_failure(
         self,
         mock_load_config: MagicMock,
@@ -1537,7 +1537,7 @@ class TestUninstallEdgeCases:
         assert "Failed: Permission denied" in result.output
 
     @patch("gobby.cli.install.uninstall_codex")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_uninstall_codex_failure(
         self,
         mock_load_config: MagicMock,
@@ -1573,7 +1573,7 @@ class TestInstallFullOutput:
     @patch("gobby.cli.install._is_claude_code_installed")
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_claude_with_all_content_types(
         self,
         mock_load_config: MagicMock,
@@ -1619,7 +1619,7 @@ class TestInstallFullOutput:
     @patch("gobby.cli.install._is_claude_code_installed")
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_gemini_with_all_content_types(
         self,
         mock_load_config: MagicMock,
@@ -1661,7 +1661,7 @@ class TestInstallFullOutput:
     @patch("gobby.cli.install._is_claude_code_installed")
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_gemini_failure(
         self,
         mock_load_config: MagicMock,
@@ -1696,7 +1696,7 @@ class TestInstallFullOutput:
     @patch("gobby.cli.install._is_claude_code_installed")
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_codex_with_all_content_types(
         self,
         mock_load_config: MagicMock,
@@ -1739,7 +1739,7 @@ class TestInstallFullOutput:
     @patch("gobby.cli.install._is_claude_code_installed")
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_codex_failure(
         self,
         mock_load_config: MagicMock,
@@ -1779,7 +1779,7 @@ class TestUninstallFullOutput:
         return CliRunner()
 
     @patch("gobby.cli.install.uninstall_gemini")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_uninstall_gemini_with_files_removed(
         self,
         mock_load_config: MagicMock,
@@ -1808,7 +1808,7 @@ class TestUninstallFullOutput:
         assert "Removed 2 files" in result.output
 
     @patch("gobby.cli.install.uninstall_gemini")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_uninstall_gemini_no_hooks_found(
         self,
         mock_load_config: MagicMock,
@@ -1849,7 +1849,7 @@ class TestInstallWithCodexAllDetected:
     @patch("gobby.cli.install._is_claude_code_installed")
     @patch("gobby.cli.install._is_gemini_cli_installed")
     @patch("gobby.cli.install._is_codex_cli_installed")
-    @patch("gobby.cli.load_config")
+    @patch("gobby.cli.load_full_config_from_db")
     def test_install_all_with_codex_detected(
         self,
         mock_load_config: MagicMock,

--- a/tests/cli/test_install_embedding_wizard.py
+++ b/tests/cli/test_install_embedding_wizard.py
@@ -119,6 +119,75 @@ class TestRunEmbeddingInstallNoInteractive:
         # Still calls installer with none to persist the disable-semantic-search config
         installer.assert_called_once_with(provider="none")
 
+    @patch("gobby.cli._detectors._is_ollama_available", return_value=False)
+    @patch("gobby.cli._detectors._is_lmstudio_available", return_value=False)
+    def test_custom_url_infers_lmstudio_without_local_provider(
+        self, mock_lms: MagicMock, mock_ollama: MagicMock
+    ) -> None:
+        installer = MagicMock(
+            return_value={
+                "success": True,
+                "provider": "lmstudio",
+                "model": "text-embedding-qwen3-embedding-4b",
+                "dim": 2560,
+                "api_base": "http://lan:1234/v1",
+                "health_check": True,
+            }
+        )
+        results: dict = {}
+
+        provider = _run_embedding_install(
+            installer,
+            results,
+            no_interactive=True,
+            api_base_override="http://lan:1234/v1",
+            model_override="text-embedding-qwen3-embedding-4b",
+            dim_override=2560,
+        )
+
+        assert provider == "lmstudio"
+        installer.assert_called_once_with(
+            provider="lmstudio",
+            openai_api_key=None,
+            model_override="text-embedding-qwen3-embedding-4b",
+            api_base_override="http://lan:1234/v1",
+            dim_override=2560,
+        )
+
+    @patch("gobby.cli._detectors._is_ollama_available", return_value=False)
+    @patch("gobby.cli._detectors._is_lmstudio_available", return_value=False)
+    def test_custom_ollama_url_infers_ollama_without_local_provider(
+        self, mock_lms: MagicMock, mock_ollama: MagicMock
+    ) -> None:
+        installer = MagicMock(
+            return_value={
+                "success": True,
+                "provider": "ollama",
+                "model": "nomic-embed-text",
+                "dim": 768,
+                "api_base": "http://custom-host:11434/v1",
+                "health_check": True,
+            }
+        )
+        results: dict = {}
+
+        provider = _run_embedding_install(
+            installer,
+            results,
+            no_interactive=True,
+            api_base_override="http://custom-host:11434/v1",
+            dim_override=768,
+        )
+
+        assert provider == "ollama"
+        installer.assert_called_once_with(
+            provider="ollama",
+            openai_api_key=None,
+            model_override=None,
+            api_base_override="http://custom-host:11434/v1",
+            dim_override=768,
+        )
+
 
 class TestRunEmbeddingInstallInteractive:
     """Test interactive menu flow."""

--- a/tests/cli/test_install_embedding_wizard.py
+++ b/tests/cli/test_install_embedding_wizard.py
@@ -80,7 +80,13 @@ class TestRunEmbeddingInstallNoInteractive:
         results: dict = {}
         provider = _run_embedding_install(installer, results, no_interactive=True)
         assert provider == "lmstudio"
-        installer.assert_called_once_with(provider="lmstudio", openai_api_key=None)
+        installer.assert_called_once_with(
+            provider="lmstudio",
+            openai_api_key=None,
+            model_override=None,
+            api_base_override=None,
+            dim_override=None,
+        )
 
     @patch("gobby.cli._detectors._is_ollama_available", return_value=True)
     @patch("gobby.cli._detectors._is_lmstudio_available", return_value=False)
@@ -138,8 +144,8 @@ class TestRunEmbeddingInstallInteractive:
             provider = _run_embedding_install(installer, results, no_interactive=False)
             click.echo(f"CHOSE={provider}")
 
-        # "1\n" selects LM Studio (first option when detected)
-        result = runner.invoke(cmd, input="1\n")
+        # "1\n" selects LM Studio; "\n" accepts the default-no on customize.
+        result = runner.invoke(cmd, input="1\n\n")
         assert result.exit_code == 0
         assert "CHOSE=lmstudio" in result.output
 
@@ -181,3 +187,110 @@ class TestRunEmbeddingInstallInteractive:
         result = runner.invoke(cmd, input="")
         assert "CHOSE=none" in result.output
         installer.assert_not_called()
+
+
+class TestRunEmbeddingInstallOverrides:
+    """CLI flag and interactive customize behavior."""
+
+    @patch("gobby.cli._detectors._is_ollama_available", return_value=False)
+    @patch("gobby.cli._detectors._is_lmstudio_available", return_value=True)
+    def test_cli_overrides_skip_customize_prompt(
+        self, mock_lms: MagicMock, mock_ollama: MagicMock
+    ) -> None:
+        installer = MagicMock(
+            return_value={
+                "success": True,
+                "provider": "lmstudio",
+                "model": "text-embedding-qwen3-embedding-4b",
+                "dim": 2560,
+                "api_base": "http://lan:1234/v1",
+                "health_check": True,
+            }
+        )
+        runner = CliRunner()
+
+        @click.command()
+        def cmd() -> None:
+            results: dict = {}
+            _run_embedding_install(
+                installer,
+                results,
+                no_interactive=False,
+                api_base_override="http://lan:1234/v1",
+                model_override="text-embedding-qwen3-embedding-4b",
+                dim_override=2560,
+            )
+
+        # "1\n" selects lmstudio. No customize prompt should fire because CLI
+        # overrides were passed, so a single confirm/abort character would
+        # itself end the test — proving the prompt did not appear.
+        result = runner.invoke(cmd, input="1\n")
+        assert result.exit_code == 0
+        installer.assert_called_once_with(
+            provider="lmstudio",
+            openai_api_key=None,
+            model_override="text-embedding-qwen3-embedding-4b",
+            api_base_override="http://lan:1234/v1",
+            dim_override=2560,
+        )
+
+    @patch("gobby.cli._detectors._is_ollama_available", return_value=False)
+    @patch("gobby.cli._detectors._is_lmstudio_available", return_value=True)
+    def test_interactive_customize_collects_overrides(
+        self, mock_lms: MagicMock, mock_ollama: MagicMock
+    ) -> None:
+        installer = MagicMock(
+            return_value={
+                "success": True,
+                "provider": "lmstudio",
+                "model": "text-embedding-qwen3-embedding-4b",
+                "dim": 2560,
+                "api_base": "http://192.168.1.10:1234/v1",
+                "health_check": True,
+            }
+        )
+        runner = CliRunner()
+
+        @click.command()
+        def cmd() -> None:
+            results: dict = {}
+            _run_embedding_install(installer, results, no_interactive=False)
+
+        # 1 → lmstudio; y → customize; URL; model; dim
+        user_input = "1\ny\nhttp://192.168.1.10:1234/v1\ntext-embedding-qwen3-embedding-4b\n2560\n"
+        result = runner.invoke(cmd, input=user_input)
+        assert result.exit_code == 0
+        kwargs = installer.call_args.kwargs
+        assert kwargs["api_base_override"] == "http://192.168.1.10:1234/v1"
+        assert kwargs["model_override"] == "text-embedding-qwen3-embedding-4b"
+        assert kwargs["dim_override"] == 2560
+
+    @patch("gobby.cli._detectors._is_ollama_available", return_value=False)
+    @patch("gobby.cli._detectors._is_lmstudio_available", return_value=True)
+    def test_interactive_customize_blank_dim_means_auto_detect(
+        self, mock_lms: MagicMock, mock_ollama: MagicMock
+    ) -> None:
+        installer = MagicMock(
+            return_value={
+                "success": True,
+                "provider": "lmstudio",
+                "model": "text-embedding-qwen3-embedding-4b",
+                "dim": 2560,
+                "api_base": "http://192.168.1.10:1234/v1",
+                "health_check": True,
+            }
+        )
+        runner = CliRunner()
+
+        @click.command()
+        def cmd() -> None:
+            results: dict = {}
+            _run_embedding_install(installer, results, no_interactive=False)
+
+        # Customize: URL + model, blank dim → installer is asked to probe.
+        user_input = "1\ny\nhttp://192.168.1.10:1234/v1\ntext-embedding-qwen3-embedding-4b\n\n"
+        result = runner.invoke(cmd, input=user_input)
+        assert result.exit_code == 0
+        kwargs = installer.call_args.kwargs
+        assert kwargs["dim_override"] is None
+        assert kwargs["model_override"] == "text-embedding-qwen3-embedding-4b"

--- a/tests/cli/test_install_prompts.py
+++ b/tests/cli/test_install_prompts.py
@@ -338,6 +338,9 @@ class TestInstallCommandSharedStores:
                 neo4j_password=None,
                 voice_flag=False,
                 project_flag=False,
+                embedding_url=None,
+                embedding_model=None,
+                embedding_dim=None,
                 no_interactive_flag=True,
                 working_dir=tmp_path,
             )

--- a/tests/cli/test_ui_coverage.py
+++ b/tests/cli/test_ui_coverage.py
@@ -308,71 +308,67 @@ class TestUiStatus:
 class TestUiDev:
     @patch("gobby.cli.ui.subprocess.run")
     @patch("gobby.cli.ui._ensure_npm_deps_installed", return_value=True)
-    @patch("gobby.cli.ui.WEB_UI_DIR")
+    @patch("gobby.cli.ui.find_web_dir")
     def test_dev_success(
         self,
-        mock_dir: MagicMock,
+        mock_find: MagicMock,
         _npm: MagicMock,
         mock_run: MagicMock,
         runner: CliRunner,
         tmp_path: Path,
     ) -> None:
-        mock_dir.exists.return_value = True
-        mock_dir.__truediv__ = lambda self, key: tmp_path / key
-        (tmp_path / "package.json").write_text("{}")
+        web_dir = tmp_path / "web"
+        web_dir.mkdir()
+        (web_dir / "package.json").write_text("{}")
+        mock_find.return_value = web_dir
         mock_run.return_value = MagicMock(returncode=0)
-        result = runner.invoke(ui, ["dev"], catch_exceptions=False)
+        result = runner.invoke(ui, ["dev"], obj={"config": MagicMock()}, catch_exceptions=False)
         assert result.exit_code == 0
         assert "Starting dev server" in result.output
+        mock_find.assert_called_with(mock_find.call_args.args[0], require_source=True)
 
-    @patch("gobby.cli.ui.WEB_UI_DIR", new=Path("/nonexistent/path"))
-    def test_dev_no_web_dir(self, runner: CliRunner) -> None:
-        result = runner.invoke(ui, ["dev"], catch_exceptions=False)
+    @patch("gobby.cli.ui.find_web_dir", return_value=None)
+    def test_dev_no_web_dir(self, _find: MagicMock, runner: CliRunner) -> None:
+        result = runner.invoke(ui, ["dev"], obj={"config": MagicMock()}, catch_exceptions=False)
         assert result.exit_code != 0
-
-    @patch("gobby.cli.ui.WEB_UI_DIR")
-    def test_dev_no_package_json(
-        self, mock_dir: MagicMock, runner: CliRunner, tmp_path: Path
-    ) -> None:
-        mock_dir.__truediv__ = lambda self, key: tmp_path / key
-        mock_dir.exists.return_value = True
-        result = runner.invoke(ui, ["dev"], catch_exceptions=False)
-        assert result.exit_code != 0
+        assert "not found" in result.output
 
     @patch("gobby.cli.ui.subprocess.run")
     @patch("gobby.cli.ui._ensure_npm_deps_installed", return_value=True)
-    @patch("gobby.cli.ui.WEB_UI_DIR")
+    @patch("gobby.cli.ui.find_web_dir")
     def test_dev_keyboard_interrupt(
         self,
-        mock_dir: MagicMock,
+        mock_find: MagicMock,
         _npm: MagicMock,
         mock_run: MagicMock,
         runner: CliRunner,
         tmp_path: Path,
     ) -> None:
-        mock_dir.exists.return_value = True
-        mock_dir.__truediv__ = lambda self, key: tmp_path / key
-        (tmp_path / "package.json").write_text("{}")
+        web_dir = tmp_path / "web"
+        web_dir.mkdir()
+        (web_dir / "package.json").write_text("{}")
+        mock_find.return_value = web_dir
         mock_run.side_effect = KeyboardInterrupt
-        result = runner.invoke(ui, ["dev"], catch_exceptions=False)
+        result = runner.invoke(ui, ["dev"], obj={"config": MagicMock()}, catch_exceptions=False)
         assert result.exit_code == 0
 
     @patch("gobby.cli.ui.subprocess.run")
     @patch("gobby.cli.ui._ensure_npm_deps_installed", return_value=True)
-    @patch("gobby.cli.ui.WEB_UI_DIR")
+    @patch("gobby.cli.ui.find_web_dir")
     def test_dev_called_process_error(
         self,
-        mock_dir: MagicMock,
+        mock_find: MagicMock,
         _npm: MagicMock,
         mock_run: MagicMock,
         runner: CliRunner,
         tmp_path: Path,
     ) -> None:
-        mock_dir.exists.return_value = True
-        mock_dir.__truediv__ = lambda self, key: tmp_path / key
-        (tmp_path / "package.json").write_text("{}")
+        web_dir = tmp_path / "web"
+        web_dir.mkdir()
+        (web_dir / "package.json").write_text("{}")
+        mock_find.return_value = web_dir
         mock_run.side_effect = subprocess.CalledProcessError(returncode=2, cmd="npm")
-        result = runner.invoke(ui, ["dev"], catch_exceptions=False)
+        result = runner.invoke(ui, ["dev"], obj={"config": MagicMock()}, catch_exceptions=False)
         assert result.exit_code == 2
 
 
@@ -380,55 +376,59 @@ class TestUiDev:
 # ui build
 # ---------------------------------------------------------------------------
 class TestUiBuild:
-    @patch("gobby.cli.ui.WEB_UI_DIR", new=Path("/nonexistent"))
-    def test_build_no_web_dir(self, runner: CliRunner) -> None:
-        result = runner.invoke(ui, ["build"], catch_exceptions=False)
+    @patch("gobby.cli.ui.find_web_dir", return_value=None)
+    def test_build_no_web_dir(self, _find: MagicMock, runner: CliRunner) -> None:
+        result = runner.invoke(ui, ["build"], obj={"config": MagicMock()}, catch_exceptions=False)
         assert result.exit_code != 0
+        assert "not found" in result.output
 
     @patch("gobby.cli.ui.subprocess.run")
     @patch("gobby.cli.ui._ensure_npm_deps_installed", return_value=True)
-    @patch("gobby.cli.ui.WEB_UI_DIR")
+    @patch("gobby.cli.ui.find_web_dir")
     def test_build_success(
         self,
-        mock_dir: MagicMock,
+        mock_find: MagicMock,
         _npm: MagicMock,
         mock_run: MagicMock,
         runner: CliRunner,
         tmp_path: Path,
     ) -> None:
-        mock_dir.exists.return_value = True
-        mock_dir.__truediv__ = lambda self, key: tmp_path / key
+        web_dir = tmp_path / "web"
+        web_dir.mkdir()
+        mock_find.return_value = web_dir
         mock_run.return_value = MagicMock(returncode=0)
-        result = runner.invoke(ui, ["build"], catch_exceptions=False)
+        result = runner.invoke(ui, ["build"], obj={"config": MagicMock()}, catch_exceptions=False)
         assert result.exit_code == 0
         assert "Build complete" in result.output
 
     @patch("gobby.cli.ui.subprocess.run")
     @patch("gobby.cli.ui._ensure_npm_deps_installed", return_value=True)
-    @patch("gobby.cli.ui.WEB_UI_DIR")
+    @patch("gobby.cli.ui.find_web_dir")
     def test_build_failure(
         self,
-        mock_dir: MagicMock,
+        mock_find: MagicMock,
         _npm: MagicMock,
         mock_run: MagicMock,
         runner: CliRunner,
         tmp_path: Path,
     ) -> None:
-        mock_dir.exists.return_value = True
-        mock_dir.__truediv__ = lambda self, key: tmp_path / key
+        web_dir = tmp_path / "web"
+        web_dir.mkdir()
+        mock_find.return_value = web_dir
         mock_run.return_value = MagicMock(returncode=1)
-        result = runner.invoke(ui, ["build"], catch_exceptions=False)
+        result = runner.invoke(ui, ["build"], obj={"config": MagicMock()}, catch_exceptions=False)
         assert result.exit_code != 0
         assert "Build failed" in result.output
 
     @patch("gobby.cli.ui._ensure_npm_deps_installed", return_value=False)
-    @patch("gobby.cli.ui.WEB_UI_DIR")
+    @patch("gobby.cli.ui.find_web_dir")
     def test_build_npm_deps_fail(
-        self, mock_dir: MagicMock, _npm: MagicMock, runner: CliRunner, tmp_path: Path
+        self, mock_find: MagicMock, _npm: MagicMock, runner: CliRunner, tmp_path: Path
     ) -> None:
-        mock_dir.exists.return_value = True
-        mock_dir.__truediv__ = lambda self, key: tmp_path / key
-        result = runner.invoke(ui, ["build"], catch_exceptions=False)
+        web_dir = tmp_path / "web"
+        web_dir.mkdir()
+        mock_find.return_value = web_dir
+        result = runner.invoke(ui, ["build"], obj={"config": MagicMock()}, catch_exceptions=False)
         assert result.exit_code != 0
 
 
@@ -436,26 +436,33 @@ class TestUiBuild:
 # ui install-deps
 # ---------------------------------------------------------------------------
 class TestUiInstallDeps:
-    @patch("gobby.cli.ui.WEB_UI_DIR", new=Path("/nonexistent"))
-    def test_install_deps_no_web_dir(self, runner: CliRunner) -> None:
-        result = runner.invoke(ui, ["install-deps"], catch_exceptions=False)
+    @patch("gobby.cli.ui.find_web_dir", return_value=None)
+    def test_install_deps_no_web_dir(self, _find: MagicMock, runner: CliRunner) -> None:
+        result = runner.invoke(
+            ui, ["install-deps"], obj={"config": MagicMock()}, catch_exceptions=False
+        )
         assert result.exit_code != 0
+        assert "not found" in result.output
 
     @patch("gobby.cli.ui._ensure_npm_deps_installed", return_value=True)
-    @patch("gobby.cli.ui.WEB_UI_DIR")
+    @patch("gobby.cli.ui.find_web_dir")
     def test_install_deps_success(
-        self, mock_dir: MagicMock, _npm: MagicMock, runner: CliRunner
+        self, mock_find: MagicMock, _npm: MagicMock, runner: CliRunner, tmp_path: Path
     ) -> None:
-        mock_dir.exists.return_value = True
-        result = runner.invoke(ui, ["install-deps"], catch_exceptions=False)
+        mock_find.return_value = tmp_path
+        result = runner.invoke(
+            ui, ["install-deps"], obj={"config": MagicMock()}, catch_exceptions=False
+        )
         assert result.exit_code == 0
         assert "installed" in result.output.lower()
 
     @patch("gobby.cli.ui._ensure_npm_deps_installed", return_value=False)
-    @patch("gobby.cli.ui.WEB_UI_DIR")
+    @patch("gobby.cli.ui.find_web_dir")
     def test_install_deps_failure(
-        self, mock_dir: MagicMock, _npm: MagicMock, runner: CliRunner
+        self, mock_find: MagicMock, _npm: MagicMock, runner: CliRunner, tmp_path: Path
     ) -> None:
-        mock_dir.exists.return_value = True
-        result = runner.invoke(ui, ["install-deps"], catch_exceptions=False)
+        mock_find.return_value = tmp_path
+        result = runner.invoke(
+            ui, ["install-deps"], obj={"config": MagicMock()}, catch_exceptions=False
+        )
         assert result.exit_code != 0

--- a/tests/cli/test_utils_coverage.py
+++ b/tests/cli/test_utils_coverage.py
@@ -107,13 +107,20 @@ def test_find_web_dir_from_config(tmp_path: Path) -> None:
 
 
 def test_find_web_dir_config_missing(tmp_path: Path) -> None:
+    import gobby
     from gobby.cli.utils import find_web_dir
 
     config = MagicMock()
     config.ui.web_dir = str(tmp_path / "nonexistent")
 
-    # Also patch cwd to avoid matching real cwd
-    with patch("gobby.cli.utils.Path.cwd", return_value=tmp_path):
+    # Patch cwd AND the gobby package path so neither fallback matches.
+    fake_pkg = tmp_path / "fake-pkg" / "__init__.py"
+    fake_pkg.parent.mkdir(parents=True)
+    fake_pkg.write_text("")
+    with (
+        patch("gobby.cli.utils.Path.cwd", return_value=tmp_path),
+        patch.object(gobby, "__file__", str(fake_pkg)),
+    ):
         result = find_web_dir(config)
     assert result is None
 
@@ -131,11 +138,65 @@ def test_find_web_dir_from_cwd(tmp_path: Path) -> None:
 
 
 def test_find_web_dir_none(tmp_path: Path) -> None:
+    import gobby
     from gobby.cli.utils import find_web_dir
 
-    with patch("gobby.cli.utils.Path.cwd", return_value=tmp_path):
+    # Patch the package-relative path away too, otherwise an installed wheel's
+    # staged ui/web/dist/ would qualify and break this "nothing found" case.
+    fake_pkg = tmp_path / "fake-pkg" / "__init__.py"
+    fake_pkg.parent.mkdir(parents=True)
+    fake_pkg.write_text("")
+    with (
+        patch("gobby.cli.utils.Path.cwd", return_value=tmp_path),
+        patch.object(gobby, "__file__", str(fake_pkg)),
+    ):
         result = find_web_dir(None)
     assert result is None
+
+
+def test_find_web_dir_accepts_install_mode_dist_only(tmp_path: Path) -> None:
+    """Installed-from-wheel layout has only dist/index.html, no package.json."""
+    from gobby.cli.utils import find_web_dir
+
+    pkg_web = tmp_path / "web"
+    (pkg_web / "dist").mkdir(parents=True)
+    (pkg_web / "dist" / "index.html").write_text("<html></html>")
+
+    config = MagicMock()
+    config.ui.web_dir = str(pkg_web)
+
+    result = find_web_dir(config)
+    assert result == pkg_web
+
+
+def test_find_web_dir_require_source_rejects_dist_only(tmp_path: Path) -> None:
+    """require_source=True must reject install-mode layouts (no package.json)."""
+    from gobby.cli.utils import find_web_dir
+
+    pkg_web = tmp_path / "web"
+    (pkg_web / "dist").mkdir(parents=True)
+    (pkg_web / "dist" / "index.html").write_text("<html></html>")
+
+    config = MagicMock()
+    config.ui.web_dir = str(pkg_web)
+
+    with patch("gobby.cli.utils.Path.cwd", return_value=tmp_path.parent):
+        result = find_web_dir(config, require_source=True)
+    assert result is None
+
+
+def test_find_web_dir_require_source_accepts_package_json(tmp_path: Path) -> None:
+    from gobby.cli.utils import find_web_dir
+
+    pkg_web = tmp_path / "web"
+    pkg_web.mkdir()
+    (pkg_web / "package.json").write_text("{}")
+
+    config = MagicMock()
+    config.ui.web_dir = str(pkg_web)
+
+    result = find_web_dir(config, require_source=True)
+    assert result == pkg_web
 
 
 # --- is_port_available ---
@@ -346,6 +407,46 @@ def test_load_full_config_from_db_with_db(tmp_path: Path) -> None:
         result = load_full_config_from_db()
     assert result is final_config
     assert mock_load.call_count == 2
+
+
+@pytest.mark.no_config_protection
+def test_load_full_config_from_db_reads_ui_enabled_from_config_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression for GH #10: CLI must see ui.enabled=true written to config_store."""
+    import yaml
+
+    from gobby.cli.utils import load_full_config_from_db
+    from gobby.storage.config_store import ConfigStore
+    from gobby.storage.database import LocalDatabase
+    from gobby.storage.migrations import run_migrations
+
+    db_path = tmp_path / "gobby.db"
+    db = LocalDatabase(db_path)
+    try:
+        run_migrations(db)
+        ConfigStore(db).set("ui.enabled", True, source="manual")
+    finally:
+        db.close()
+
+    # Steer GOBBY_TEST_PROTECT's database override at our tmp db, not the global one.
+    monkeypatch.setenv("GOBBY_DATABASE_PATH", str(db_path))
+
+    bootstrap_yaml = tmp_path / "bootstrap.yaml"
+    bootstrap_yaml.write_text(
+        yaml.safe_dump(
+            {
+                "database_path": str(db_path),
+                "daemon_port": 60887,
+                "websocket_port": 60888,
+                "ui_port": 60889,
+                "bind_host": "127.0.0.1",
+            }
+        )
+    )
+
+    result = load_full_config_from_db(config_file=str(bootstrap_yaml))
+    assert result.ui.enabled is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/config/test_mcp_config.py
+++ b/tests/config/test_mcp_config.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from gobby.config.mcp import MCPConfigManager
+from gobby.config.mcp import MCPConfigManager, migrate_legacy_mcp_config
 from gobby.mcp_proxy.manager import MCPServerConfig
 
 pytestmark = pytest.mark.unit
@@ -51,11 +51,13 @@ class TestMCPConfigManagerInit:
 
     def test_init_with_default_path(self) -> None:
         """Test that init uses default path when not specified."""
-        with patch.object(Path, "expanduser", return_value=Path("/tmp/test/.gobby/.mcp.json")):
+        with patch.object(
+            Path, "expanduser", return_value=Path("/tmp/test/.gobby/mcp-servers.json")
+        ):
             with patch.object(Path, "mkdir"):
                 with patch.object(Path, "exists", return_value=True):
                     manager = MCPConfigManager()
-                    assert ".mcp.json" in str(manager.config_path)
+                    assert "mcp-servers.json" in str(manager.config_path)
 
 
 class TestMCPConfigManagerReadConfig:
@@ -511,3 +513,45 @@ class TestMCPConfigManagerListServers:
         names = manager.list_servers()
 
         assert names == ["server1", "server2", "server3"]
+
+
+class TestMigrateLegacyMcpConfig:
+    """Tests for migrate_legacy_mcp_config helper."""
+
+    def test_renames_legacy_when_new_missing(self, tmp_path) -> None:
+        legacy = tmp_path / ".mcp.json"
+        new = tmp_path / "mcp-servers.json"
+        legacy.write_text('{"servers": []}')
+
+        assert migrate_legacy_mcp_config(new_path=new, legacy_path=legacy) is True
+
+        assert not legacy.exists()
+        assert new.read_text() == '{"servers": []}'
+
+    def test_no_op_when_legacy_missing(self, tmp_path) -> None:
+        legacy = tmp_path / ".mcp.json"
+        new = tmp_path / "mcp-servers.json"
+
+        assert migrate_legacy_mcp_config(new_path=new, legacy_path=legacy) is False
+        assert not new.exists()
+
+    def test_no_op_when_both_exist(self, tmp_path) -> None:
+        legacy = tmp_path / ".mcp.json"
+        new = tmp_path / "mcp-servers.json"
+        legacy.write_text("legacy")
+        new.write_text("new")
+
+        assert migrate_legacy_mcp_config(new_path=new, legacy_path=legacy) is False
+
+        assert legacy.read_text() == "legacy"
+        assert new.read_text() == "new"
+
+    def test_creates_parent_directory(self, tmp_path) -> None:
+        legacy = tmp_path / ".mcp.json"
+        new = tmp_path / "nested" / "mcp-servers.json"
+        legacy.write_text('{"servers": []}')
+
+        assert migrate_legacy_mcp_config(new_path=new, legacy_path=legacy) is True
+
+        assert new.parent.exists()
+        assert new.read_text() == '{"servers": []}'

--- a/tests/servers/test_app_factory_production_ui.py
+++ b/tests/servers/test_app_factory_production_ui.py
@@ -1,0 +1,81 @@
+"""Regression tests for `_mount_production_ui` (GH #10).
+
+Asserts the production UI mount works against an installed-from-wheel
+layout (only ``dist/`` exists, no ``package.json``) so that
+``GET /`` returns ``index.html`` instead of 404.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from gobby.servers.app_factory import _mount_production_ui
+
+pytestmark = pytest.mark.unit
+
+
+def _make_dist_only_web_dir(root: Path) -> Path:
+    web = root / "web"
+    dist = web / "dist"
+    dist.mkdir(parents=True)
+    (dist / "index.html").write_text("<html><body>UI</body></html>")
+    assets = dist / "assets"
+    assets.mkdir()
+    (assets / "app.js").write_text("// app bundle")
+    return web
+
+
+def _server_stub(web_dir: Path) -> SimpleNamespace:
+    config = SimpleNamespace(ui=SimpleNamespace(web_dir=str(web_dir)))
+    return SimpleNamespace(services=SimpleNamespace(config=config))
+
+
+def test_mount_production_ui_serves_index_on_root(tmp_path: Path) -> None:
+    web_dir = _make_dist_only_web_dir(tmp_path)
+    app = FastAPI()
+    _mount_production_ui(app, _server_stub(web_dir))  # type: ignore[arg-type]
+
+    client = TestClient(app)
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "<html>" in resp.text
+
+
+def test_mount_production_ui_serves_assets(tmp_path: Path) -> None:
+    web_dir = _make_dist_only_web_dir(tmp_path)
+    app = FastAPI()
+    _mount_production_ui(app, _server_stub(web_dir))  # type: ignore[arg-type]
+
+    client = TestClient(app)
+    resp = client.get("/assets/app.js")
+    assert resp.status_code == 200
+    assert "app bundle" in resp.text
+
+
+def test_mount_production_ui_falls_back_to_index_for_spa_routes(tmp_path: Path) -> None:
+    web_dir = _make_dist_only_web_dir(tmp_path)
+    app = FastAPI()
+    _mount_production_ui(app, _server_stub(web_dir))  # type: ignore[arg-type]
+
+    client = TestClient(app)
+    resp = client.get("/some/spa/route")
+    assert resp.status_code == 200
+    assert "<html>" in resp.text
+
+
+def test_mount_production_ui_no_op_when_dist_missing(tmp_path: Path) -> None:
+    web_dir = tmp_path / "web"
+    web_dir.mkdir()
+    (web_dir / "package.json").write_text("{}")
+
+    app = FastAPI()
+    _mount_production_ui(app, _server_stub(web_dir))  # type: ignore[arg-type]
+
+    client = TestClient(app)
+    resp = client.get("/")
+    assert resp.status_code == 404

--- a/tests/test_build_backend.py
+++ b/tests/test_build_backend.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import importlib
 import sys
+import zipfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -20,6 +22,12 @@ def _load_backend(repo_root: Path) -> object:
         return importlib.import_module("build_backend")
     finally:
         sys.path.pop(0)
+
+
+def _write_wheel(path: Path, members: list[str]) -> None:
+    with zipfile.ZipFile(path, "w") as wheel:
+        for member in members:
+            wheel.writestr(member, "")
 
 
 def test_stage_ui_copies_dist_to_package(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -91,3 +99,58 @@ def test_stage_ui_reuses_pre_staged_when_no_web(
     backend._stage_ui()  # type: ignore[attr-defined]
 
     assert (staged_dir / "index.html").read_text() == "pre-staged"
+
+
+def test_build_wheel_accepts_wheel_with_ui_index(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = tmp_path
+    (repo_root / "build_backend").mkdir()
+    real_module = Path(__file__).resolve().parent.parent / "build_backend" / "__init__.py"
+    (repo_root / "build_backend" / "__init__.py").write_text(real_module.read_text())
+    wheel_dir = repo_root / "dist"
+    wheel_dir.mkdir()
+
+    backend = _load_backend(repo_root)
+    monkeypatch.setattr(backend, "_stage_ui", lambda: None)
+
+    def fake_build_wheel(
+        wheel_directory: str,
+        config_settings: dict[str, object] | None,
+        metadata_directory: str | None,
+    ) -> str:
+        wheel_path = Path(wheel_directory) / "gobby-0-py3-none-any.whl"
+        _write_wheel(wheel_path, ["gobby/ui/web/dist/index.html"])
+        return wheel_path.name
+
+    monkeypatch.setattr(backend, "_orig", lambda: SimpleNamespace(build_wheel=fake_build_wheel))
+
+    assert backend.build_wheel(str(wheel_dir)) == "gobby-0-py3-none-any.whl"  # type: ignore[attr-defined]
+
+
+def test_build_wheel_rejects_wheel_missing_ui_index(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = tmp_path
+    (repo_root / "build_backend").mkdir()
+    real_module = Path(__file__).resolve().parent.parent / "build_backend" / "__init__.py"
+    (repo_root / "build_backend" / "__init__.py").write_text(real_module.read_text())
+    wheel_dir = repo_root / "dist"
+    wheel_dir.mkdir()
+
+    backend = _load_backend(repo_root)
+    monkeypatch.setattr(backend, "_stage_ui", lambda: None)
+
+    def fake_build_wheel(
+        wheel_directory: str,
+        config_settings: dict[str, object] | None,
+        metadata_directory: str | None,
+    ) -> str:
+        wheel_path = Path(wheel_directory) / "gobby-0-py3-none-any.whl"
+        _write_wheel(wheel_path, ["gobby/__init__.py"])
+        return wheel_path.name
+
+    monkeypatch.setattr(backend, "_orig", lambda: SimpleNamespace(build_wheel=fake_build_wheel))
+
+    with pytest.raises(RuntimeError, match="gobby/ui/web/dist/index.html"):
+        backend.build_wheel(str(wheel_dir))  # type: ignore[attr-defined]

--- a/tests/test_build_backend.py
+++ b/tests/test_build_backend.py
@@ -1,0 +1,93 @@
+"""Tests for the PEP 517 build backend wrapper that stages the web UI."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _load_backend(repo_root: Path) -> object:
+    """Import build_backend rooted at ``repo_root``."""
+    sys.path.insert(0, str(repo_root))
+    try:
+        if "build_backend" in sys.modules:
+            del sys.modules["build_backend"]
+        return importlib.import_module("build_backend")
+    finally:
+        sys.path.pop(0)
+
+
+def test_stage_ui_copies_dist_to_package(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo_root = tmp_path
+    (repo_root / "build_backend").mkdir()
+    # Symlink __init__.py from the real module so we exercise the actual code.
+    real_module = Path(__file__).resolve().parent.parent / "build_backend" / "__init__.py"
+    (repo_root / "build_backend" / "__init__.py").write_text(real_module.read_text())
+
+    web = repo_root / "web"
+    dist = web / "dist"
+    dist.mkdir(parents=True)
+    (web / "package.json").write_text("{}")
+    (dist / "index.html").write_text("<html></html>")
+    (dist / "assets").mkdir()
+    (dist / "assets" / "app.js").write_text("// js")
+
+    # Skip the npm step; we only want to test the copy phase.
+    monkeypatch.setenv("GOBBY_SKIP_UI_BUILD", "0")
+    # Force no-npm path so npm ci is never invoked.
+    monkeypatch.setattr("shutil.which", lambda name: None if name == "npm" else "/usr/bin/" + name)
+
+    backend = _load_backend(repo_root)
+    backend._stage_ui()  # type: ignore[attr-defined]
+
+    staged = repo_root / "src" / "gobby" / "ui" / "web" / "dist"
+    assert (staged / "index.html").read_text() == "<html></html>"
+    assert (staged / "assets" / "app.js").read_text() == "// js"
+
+
+def test_stage_ui_skip_env_var(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo_root = tmp_path
+    (repo_root / "build_backend").mkdir()
+    real_module = Path(__file__).resolve().parent.parent / "build_backend" / "__init__.py"
+    (repo_root / "build_backend" / "__init__.py").write_text(real_module.read_text())
+
+    # Create a stale dist; staging must NOT touch it.
+    web_dist = repo_root / "web" / "dist"
+    web_dist.mkdir(parents=True)
+    (web_dist / "index.html").write_text("fresh")
+    staged_dir = repo_root / "src" / "gobby" / "ui" / "web" / "dist"
+    staged_dir.mkdir(parents=True)
+    (staged_dir / "index.html").write_text("stale")
+
+    monkeypatch.setenv("GOBBY_SKIP_UI_BUILD", "1")
+
+    backend = _load_backend(repo_root)
+    backend._stage_ui()  # type: ignore[attr-defined]
+
+    assert (staged_dir / "index.html").read_text() == "stale"
+
+
+def test_stage_ui_reuses_pre_staged_when_no_web(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = tmp_path
+    (repo_root / "build_backend").mkdir()
+    real_module = Path(__file__).resolve().parent.parent / "build_backend" / "__init__.py"
+    (repo_root / "build_backend" / "__init__.py").write_text(real_module.read_text())
+
+    # No web/ tree at all; only a pre-staged dist exists (sdist install scenario).
+    staged_dir = repo_root / "src" / "gobby" / "ui" / "web" / "dist"
+    staged_dir.mkdir(parents=True)
+    (staged_dir / "index.html").write_text("pre-staged")
+
+    monkeypatch.delenv("GOBBY_SKIP_UI_BUILD", raising=False)
+
+    backend = _load_backend(repo_root)
+    backend._stage_ui()  # type: ignore[attr-defined]
+
+    assert (staged_dir / "index.html").read_text() == "pre-staged"

--- a/uv.lock
+++ b/uv.lock
@@ -1246,7 +1246,7 @@ wheels = [
 
 [[package]]
 name = "gobby"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Cut v0.4.2 release branch into main.
- Adds custom embedding endpoint/model/dim install support and the no-local-provider follow-up for GH #9.
- Ships and verifies production web UI assets in wheels, documents installed UI on :60887, and corrects GH #10.
- Includes the MCP config rename/migration for GH #11 and release changelog updates.

## Validation
- uv run gobby restart
- uv run gobby health
- GOBBY_TEST_PROTECT=1 uv run pytest tests/cli/test_install_embedding_wizard.py tests/cli/installers/test_embedding_installer.py tests/test_build_backend.py tests/servers/test_app_factory_production_ui.py -v
- uv run ruff check src/
- uv run ruff format --check src/
- GOBBY_TEST_PROTECT=1 uv run mypy src/ --no-incremental --strict
- GOBBY_SKIP_UI_BUILD=1 uv build
- git push pre-push hooks: lint, format, type_check, ts_check, frontend_tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.4.2

* **New Features**
  * Added CLI flags (`--embedding-url`, `--embedding-model`, `--embedding-dim`) to configure custom OpenAI-compatible embedding endpoints during installation with automatic dimension detection.

* **Bug Fixes**
  * Fixed web UI packaging in distributions.
  * Fixed MCP server configuration migration to new location.

* **Documentation**
  * Updated web UI port references: installed UI runs on `:60887`, dev mode on `:60889`.
  * Updated MCP configuration location to `mcp-servers.json`.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GobbyAI/gobby/pull/12)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->