### PR TITLE
[0.4.50] Deslug Claude native titles

### DIFF
--- a/src/gobby/memory/title_heuristics.py
+++ b/src/gobby/memory/title_heuristics.py
@@ -306,7 +306,12 @@ def normalize_title_candidate(value: Any) -> str | None:
     return title
 
 
-def normalize_native_title(value: Any) -> str | None:
+def _normalize_claude_native_title(title: str) -> str:
+    """Normalize Claude ai-title slugs into readable titles."""
+    return re.sub(r"\s+", " ", title.replace("-", " ")).strip()
+
+
+def normalize_native_title(value: Any, *, source: str | None = None) -> str | None:
     """Validate and normalize a CLI-native session title (Claude ai-title, Droid sessionTitle).
 
     Native titles are AI-synthesized by the CLI itself, but quality varies:
@@ -330,6 +335,10 @@ def normalize_native_title(value: Any) -> str | None:
         return None
     if is_template_placeholder(title):
         return None
+    if source == "claude":
+        title = _normalize_claude_native_title(title)
+        if not title:
+            return None
     return _truncate_title(title)
 
 

--- a/src/gobby/sessions/processor_transcripts.py
+++ b/src/gobby/sessions/processor_transcripts.py
@@ -44,8 +44,14 @@ class ProcessorTranscriptMixin:
                 session = self.session_manager.get(session_id)
                 if session is not None and _can_replace_with_native_title(session):
                     # Use the last title message (latest ai-title update wins).
-                    raw_title = title_msgs[-1].content
-                    title = normalize_native_title(raw_title)
+                    title_msg = title_msgs[-1]
+                    raw_title = title_msg.content
+                    source = title_msg.source
+                    if source is None:
+                        parser = self._parsers.get(session_id)
+                        parser_source = getattr(parser, "cli_name", None)
+                        source = parser_source if isinstance(parser_source, str) else None
+                    title = normalize_native_title(raw_title, source=source)
                     if title:
                         self.session_manager.update_title(
                             session_id,

--- a/tests/memory/test_digest.py
+++ b/tests/memory/test_digest.py
@@ -290,6 +290,22 @@ class TestNormalizeNativeTitle:
     def test_accepts_clean_title(self) -> None:
         assert normalize_native_title("Fix authentication bug") == "Fix authentication bug"
 
+    def test_claude_native_title_replaces_slug_dashes(self) -> None:
+        assert (
+            normalize_native_title(
+                "check-gobby-logs-for-tmux-warnings",
+                source="claude",
+            )
+            == "check gobby logs for tmux warnings"
+        )
+        assert (
+            normalize_native_title(
+                "check-gobby-logs-for-tmux-warnings",
+                source="droid",
+            )
+            == "check-gobby-logs-for-tmux-warnings"
+        )
+
     def test_rejects_new_session_placeholder(self) -> None:
         assert normalize_native_title("New Session") is None
         assert normalize_native_title("new session") is None

--- a/tests/sessions/test_sessions_processor_unit.py
+++ b/tests/sessions/test_sessions_processor_unit.py
@@ -1647,7 +1647,13 @@ class TestExtractNativeTitles:
     """Tests for _extract_native_titles — intercepts session_title messages
     before stats/render, updates the session title, and returns non-title msgs."""
 
-    def _make_title_msg(self, content: str, index: int = 0) -> ParsedMessage:
+    def _make_title_msg(
+        self,
+        content: str,
+        index: int = 0,
+        *,
+        source: str | None = None,
+    ) -> ParsedMessage:
         return ParsedMessage(
             index=index,
             role="system",
@@ -1658,6 +1664,7 @@ class TestExtractNativeTitles:
             tool_result=None,
             timestamp=datetime.now(),
             raw_json={},
+            source=source,
         )
 
     def _make_text_msg(self, content: str, index: int = 1) -> ParsedMessage:
@@ -1692,6 +1699,28 @@ class TestExtractNativeTitles:
         assert result[0].content_type == "text"
         session_manager.update_title.assert_called_once_with(
             "sid", "Fix auth bug", title_source="native"
+        )
+
+    def test_claude_title_slug_dashes_become_spaces(self, mock_db) -> None:
+        processor = SessionMessageProcessor(mock_db)
+        session_manager = MagicMock()
+        session = MagicMock()
+        session.title = ""
+        session.title_source = ""
+        session_manager.get.return_value = session
+        processor.session_manager = session_manager
+
+        messages = [
+            self._make_title_msg(
+                "check-gobby-logs-for-tmux-warnings",
+                source="claude",
+            )
+        ]
+        result = processor._extract_native_titles("sid", messages)
+
+        assert result == []
+        session_manager.update_title.assert_called_once_with(
+            "sid", "check gobby logs for tmux warnings", title_source="native"
         )
 
     def test_skips_when_session_manager_is_none(self, mock_db) -> None:


### PR DESCRIPTION
Stacked review branch based on 0.4.49.\n\nScope:\n- Claude native title deslugging.\n\nReview:\n- This PR is intentionally stacked for focused CodeRabbit review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native titles are now more readable when they come from Claude sessions, with dashed slug-style titles automatically converted into normal text.
* **Bug Fixes**
  * Improved title detection so session titles are normalized more consistently before being saved.
  * Empty or invalid title results are now handled more reliably, preventing unusable titles from being applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->