### PR TITLE
[0.4.51] Prevent duplicate agent profile reinjection

### DIFF
--- a/src/gobby/hooks/event_handlers/_agent.py
+++ b/src/gobby/hooks/event_handlers/_agent.py
@@ -20,6 +20,24 @@ _GOBBY_CMD_PATTERN = re.compile(
 _HELP_SKILL_LIST_LIMIT = 50
 
 
+def _has_positive_count(value: Any) -> bool:
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return value > 0
+    if isinstance(value, str) and value.isdigit():
+        return int(value) > 0
+    return False
+
+
+def _has_prior_session_activity(session: Any | None) -> bool:
+    if session is None:
+        return False
+    return _has_positive_count(getattr(session, "message_count", 0)) or _has_positive_count(
+        getattr(session, "turn_count", 0)
+    )
+
+
 def _load_agent_prompt(
     name: str,
     context: dict[str, Any] | None = None,
@@ -164,13 +182,18 @@ class AgentEventHandlerMixin(EventHandlersBase):
         variables = sv_mgr.get_variables(session_id)
 
         identity_reinject = bool(variables.get("_agent_identity_reinject"))
-        if variables.get("_agent_context_injected") and not identity_reinject:
-            return
+        rehydrate_pending = bool(variables.get("_agent_context_rehydrate_pending"))
 
-        agent_name = variables.get("_agent_type", "default")
+        if (
+            variables.get("_agent_context_injected")
+            and not identity_reinject
+            and not rehydrate_pending
+        ):
+            return
 
         # Get project_id for project-specific agent resolution
         project_id = None
+        session_row = None
         try:
             session_row = self._session_manager.get(session_id)
             if session_row:
@@ -182,6 +205,16 @@ class AgentEventHandlerMixin(EventHandlersBase):
                 e,
                 exc_info=True,
             )
+
+        if (
+            not identity_reinject
+            and not rehydrate_pending
+            and _has_prior_session_activity(session_row)
+        ):
+            sv_mgr.merge_variables(session_id, {"_agent_context_injected": True})
+            return
+
+        agent_name = variables.get("_agent_type", "default")
 
         from gobby.workflows.agent_resolver import resolve_agent
 
@@ -201,6 +234,7 @@ class AgentEventHandlerMixin(EventHandlersBase):
             {
                 "_agent_context_injected": True,
                 "_agent_identity_reinject": False,
+                "_agent_context_rehydrate_pending": False,
             },
         )
 

--- a/src/gobby/hooks/event_handlers/_session_start/flow.py
+++ b/src/gobby/hooks/event_handlers/_session_start/flow.py
@@ -148,7 +148,10 @@ def _reset_agent_context_injection(handler: Any, session_id: str | None) -> None
 
         SessionVariableManager(handler._session_manager.db).merge_variables(
             session_id,
-            {"_agent_context_injected": False},
+            {
+                "_agent_context_injected": False,
+                "_agent_context_rehydrate_pending": True,
+            },
         )
     except (json.JSONDecodeError, KeyError, psycopg.Error) as e:
         handler.logger.warning(f"Failed to reset agent context injection flag: {e}")

--- a/src/gobby/hooks/session_coordinator.py
+++ b/src/gobby/hooks/session_coordinator.py
@@ -283,16 +283,6 @@ class SessionCoordinator:
                     self.logger.warning(f"Failed to re-register session {session.id}: {e}")
                     continue
 
-                # Reset _agent_context_injected so the next before_agent
-                # re-injects instructions lost when the daemon restarted.
-                # Failure here must not affect the registered_count above.
-                try:
-                    self._reset_deferred_injection_flags(session.id)
-                except Exception as e:
-                    self.logger.warning(
-                        f"Failed to reset deferred injection flags for {session.id}: {e}"
-                    )
-
             if registered_count > 0:
                 self.logger.info(
                     f"Re-registered {registered_count} active/paused sessions "
@@ -304,31 +294,6 @@ class SessionCoordinator:
         except Exception as e:
             self.logger.warning(f"Failed to re-register active/paused sessions: {e}")
             return 0
-
-    def _reset_deferred_injection_flags(self, session_id: str) -> None:
-        """Reset session variables that gate deferred context injection.
-
-        After a daemon restart the DB still has _agent_context_injected=True
-        from the previous run, which causes _inject_agent_instructions_if_needed
-        to skip re-injecting instructions on the next before_agent.
-        """
-        if not self._session_manager:
-            return
-        try:
-            from gobby.workflows.state_manager import SessionVariableManager
-
-            sv_mgr = SessionVariableManager(self._session_manager.db)
-            sv_mgr.merge_variables(
-                session_id,
-                {
-                    "_agent_context_injected": False,
-                    "_agent_identity_reinject": False,
-                },
-            )
-        except Exception as e:
-            self.logger.warning(
-                f"Failed to reset deferred injection flags for session {session_id}: {e}"
-            )
 
     def start_agent_run(self, agent_run_id: str) -> bool:
         """

--- a/src/gobby/install/shared/workflows/variables/gobby-default-variables.yaml
+++ b/src/gobby/install/shared/workflows/variables/gobby-default-variables.yaml
@@ -114,6 +114,9 @@ variables:
   _agent_context_injected:
     value: false
     description: "True after agent identity and instructions have been sent on first before_agent"
+  _agent_context_rehydrate_pending:
+    value: false
+    description: "True when the next before_agent should rehydrate agent identity after explicit context loss"
   _startup_context_injected:
     value: false
     description: "True after full SessionStart startup context has been sent"

--- a/tests/hooks/test_agent_events_coverage.py
+++ b/tests/hooks/test_agent_events_coverage.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from importlib.resources import files
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 import yaml
@@ -166,6 +166,7 @@ class TestHandleBeforeAgent:
                     "_agent_type": "default",
                     "_active_skill_names": ["brevity"],
                     "_agent_context_injected": False,
+                    "_agent_context_rehydrate_pending": True,
                 },
             ),
             patch(
@@ -199,6 +200,7 @@ class TestHandleBeforeAgent:
             {
                 "_agent_context_injected": True,
                 "_agent_identity_reinject": False,
+                "_agent_context_rehydrate_pending": False,
             },
         )
 
@@ -224,10 +226,12 @@ class TestHandleBeforeAgent:
                     {
                         "_agent_type": "default",
                         "_agent_context_injected": False,
+                        "_agent_context_rehydrate_pending": True,
                     },
                     {
                         "_agent_type": "default",
                         "_agent_context_injected": True,
+                        "_agent_context_rehydrate_pending": False,
                     },
                 ],
             ),
@@ -250,8 +254,169 @@ class TestHandleBeforeAgent:
             {
                 "_agent_context_injected": True,
                 "_agent_identity_reinject": False,
+                "_agent_context_rehydrate_pending": False,
             },
         )
+
+    def test_stale_agent_context_false_with_prior_activity_repairs_without_preamble(
+        self,
+    ) -> None:
+        handler = _TestHandler()
+        handler._skill_manager = None
+        handler._session_manager.get.return_value = MagicMock(
+            project_id="proj-1",
+            message_count=186,
+            turn_count=74,
+        )
+        event = _make_event(
+            data={"prompt": "hello"},
+            metadata={"_platform_session_id": "sess-1"},
+        )
+
+        with (
+            patch(
+                "gobby.workflows.state_manager.SessionVariableManager.get_variables",
+                return_value={
+                    "_agent_type": "default",
+                    "_agent_context_injected": False,
+                    "_agent_context_rehydrate_pending": False,
+                },
+            ),
+            patch(
+                "gobby.workflows.state_manager.SessionVariableManager.merge_variables",
+            ) as mock_merge,
+            patch("gobby.workflows.agent_resolver.resolve_agent") as mock_resolve_agent,
+        ):
+            result = handler.handle_before_agent(event)
+
+        assert result.decision == "allow"
+        assert result.context is None
+        assert "## Role" not in (result.context or "")
+        handler._session_manager.update_session_status.assert_called_once_with("sess-1", "active")
+        handler._session_manager.reset_transcript_processed.assert_called_once_with("sess-1")
+        handler._session_manager.get.assert_called_once_with("sess-1")
+        mock_resolve_agent.assert_not_called()
+        mock_merge.assert_called_once_with("sess-1", {"_agent_context_injected": True})
+
+    def test_persona_switch_reinjects_agent_preamble_once(self) -> None:
+        handler = _TestHandler()
+        handler._skill_manager = None
+        handler._session_manager.get.return_value = MagicMock(
+            project_id="proj-1",
+            message_count=12,
+            turn_count=5,
+        )
+        event = _make_event(
+            data={"prompt": "hello"},
+            metadata={"_platform_session_id": "sess-1"},
+        )
+        agent = AgentDefinitionBody(
+            name="operator",
+            role="Act as the operator.",
+            goal="Keep the persona current.",
+            personality="Precise.",
+            instructions="Use the active persona.",
+        )
+
+        with (
+            patch(
+                "gobby.workflows.state_manager.SessionVariableManager.get_variables",
+                side_effect=[
+                    {
+                        "_agent_type": "operator",
+                        "_agent_context_injected": True,
+                        "_agent_identity_reinject": True,
+                        "_agent_context_rehydrate_pending": False,
+                    },
+                    {
+                        "_agent_type": "operator",
+                        "_agent_context_injected": True,
+                        "_agent_identity_reinject": False,
+                        "_agent_context_rehydrate_pending": False,
+                    },
+                ],
+            ),
+            patch(
+                "gobby.workflows.state_manager.SessionVariableManager.merge_variables",
+            ) as mock_merge,
+            patch("gobby.workflows.agent_resolver.resolve_agent", return_value=agent),
+        ):
+            first = handler.handle_before_agent(event)
+            second = handler.handle_before_agent(event)
+
+        assert first.context is not None
+        assert first.context.count("## Role") == 1
+        assert "## Role\nAct as the operator." in first.context
+        assert second.context is None
+        assert mock_merge.call_args_list == [
+            call(
+                "sess-1",
+                {
+                    "_agent_context_injected": True,
+                    "_agent_identity_reinject": False,
+                    "_agent_context_rehydrate_pending": False,
+                },
+            )
+        ]
+
+    def test_explicit_rehydrate_reinjects_agent_preamble_once(self) -> None:
+        handler = _TestHandler()
+        handler._skill_manager = None
+        handler._session_manager.get.return_value = MagicMock(
+            project_id="proj-1",
+            message_count=20,
+            turn_count=9,
+        )
+        event = _make_event(
+            data={"prompt": "hello"},
+            metadata={"_platform_session_id": "sess-1"},
+        )
+        agent = AgentDefinitionBody(
+            name="default",
+            role="Act as the daemon.",
+            goal="Restore prompt context.",
+            personality="Direct.",
+            instructions="Rehydrate after context loss.",
+        )
+
+        with (
+            patch(
+                "gobby.workflows.state_manager.SessionVariableManager.get_variables",
+                side_effect=[
+                    {
+                        "_agent_type": "default",
+                        "_agent_context_injected": False,
+                        "_agent_context_rehydrate_pending": True,
+                    },
+                    {
+                        "_agent_type": "default",
+                        "_agent_context_injected": True,
+                        "_agent_context_rehydrate_pending": False,
+                    },
+                ],
+            ),
+            patch(
+                "gobby.workflows.state_manager.SessionVariableManager.merge_variables",
+            ) as mock_merge,
+            patch("gobby.workflows.agent_resolver.resolve_agent", return_value=agent),
+        ):
+            first = handler.handle_before_agent(event)
+            second = handler.handle_before_agent(event)
+
+        assert first.context is not None
+        assert first.context.count("## Role") == 1
+        assert "## Goal\nRestore prompt context." in first.context
+        assert second.context is None
+        assert mock_merge.call_args_list == [
+            call(
+                "sess-1",
+                {
+                    "_agent_context_injected": True,
+                    "_agent_identity_reinject": False,
+                    "_agent_context_rehydrate_pending": False,
+                },
+            )
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hooks/test_session_coordinator.py
+++ b/tests/hooks/test_session_coordinator.py
@@ -21,7 +21,7 @@ import logging
 import threading
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -313,8 +313,8 @@ class TestSessionLifecycleTransitions:
         assert count == 1
         assert mock_message_processor.register_session.call_count == 2
 
-    def test_reregister_resets_agent_context_injected(self) -> None:
-        """Test re-registration resets deferred persona injection flags."""
+    def test_reregister_does_not_reset_agent_context_flags(self) -> None:
+        """Test re-registration only restores transcript processing."""
         mock_session_storage = MagicMock()
         mock_session_storage.list.side_effect = lambda status, limit: {
             "active": [
@@ -336,22 +336,20 @@ class TestSessionLifecycleTransitions:
         )
 
         with patch("gobby.workflows.state_manager.SessionVariableManager") as MockSVMgr:
-            mock_sv_instance = MockSVMgr.return_value
             count = coordinator.reregister_active_sessions()
 
         assert count == 1
-        MockSVMgr.assert_called_once_with(mock_session_storage.db)
-        assert MockSVMgr.call_count == 1
-        assert MockSVMgr.call_args is not None
-        mock_sv_instance.merge_variables.assert_called_once_with(
+        assert mock_session_storage.list.call_args_list == [
+            call(status="active", limit=1000),
+            call(status="paused", limit=1000),
+        ]
+        mock_message_processor.register_session.assert_called_once_with(
             "session-1",
-            {
-                "_agent_context_injected": False,
-                "_agent_identity_reinject": False,
-            },
+            "/path/to/1.jsonl",
+            source="claude",
         )
-        assert mock_sv_instance.merge_variables.call_count == 1
-        assert mock_sv_instance.merge_variables.call_args is not None
+        assert mock_message_processor.register_session.call_count == 1
+        MockSVMgr.assert_not_called()
 
 
 class TestAgentRunCompletion:

--- a/tests/hooks/test_session_start_handlers.py
+++ b/tests/hooks/test_session_start_handlers.py
@@ -687,7 +687,10 @@ class TestSessionStartPreCreatedSession:
         assert (
             call(
                 "sess-first-123",
-                {"_agent_context_injected": False},
+                {
+                    "_agent_context_injected": False,
+                    "_agent_context_rehydrate_pending": True,
+                },
             )
             in mock_svm.merge_variables.call_args_list
         )
@@ -759,7 +762,10 @@ class TestSessionStartPreCreatedSession:
         assert (
             call(
                 mock_session.id,
-                {"_agent_context_injected": False},
+                {
+                    "_agent_context_injected": False,
+                    "_agent_context_rehydrate_pending": True,
+                },
             )
             in mock_svm.merge_variables.call_args_list
         )


### PR DESCRIPTION
Stacked review branch based on 0.4.50.\n\nScope:\n- Duplicate agent profile reinjection fix.\n\nReview:\n- This PR is intentionally stacked for focused CodeRabbit review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking when agent context needs to be rehydrated after a session reset.

* **Bug Fixes**
  * Improved agent prompt handling so prior session activity is recognized more reliably before deciding whether to inject context.
  * Ensured re-registration of active sessions no longer clears deferred context state unexpectedly.

* **Tests**
  * Updated coverage for session start, agent context injection, and session re-registration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->