### PR TITLE
fix: allow the daemon to start on Windows (fcntl import + asyncio signal handlers)

### DIFF
--- a/src/gobby/agents/tmux/pty_bridge.py
+++ b/src/gobby/agents/tmux/pty_bridge.py
@@ -11,13 +11,22 @@ This gives full terminal fidelity (Ctrl+C, arrows, Tab, etc.) unlike
 from __future__ import annotations
 
 import asyncio
-import fcntl
 import logging
 import os
 import struct
-import termios
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+
+try:  # pragma: no cover - exercised per-platform
+    import fcntl
+    import termios
+
+    PTY_SUPPORTED = True
+except ImportError:  # pragma: no cover - Windows has no fcntl/termios
+    fcntl = None  # type: ignore[assignment]
+    termios = None  # type: ignore[assignment]
+
+    PTY_SUPPORTED = False
 
 from gobby.config.tmux import TmuxConfig
 
@@ -75,6 +84,12 @@ class TmuxPTYBridge:
         async with self._lock:
             if streaming_id in self._bridges:
                 raise RuntimeError(f"Bridge {streaming_id} already exists")
+
+        if not PTY_SUPPORTED:
+            raise RuntimeError(
+                "tmux PTY bridging requires a POSIX platform (fcntl/termios); "
+                "it is unavailable on this system"
+            )
 
         master_fd, slave_fd = os.openpty()
 
@@ -172,7 +187,7 @@ class TmuxPTYBridge:
         async with self._lock:
             bridge = self._bridges.get(streaming_id)
 
-        if bridge:
+        if bridge and PTY_SUPPORTED:
             try:
                 fcntl.ioctl(
                     bridge.master_fd,

--- a/src/gobby/runner_maintenance.py
+++ b/src/gobby/runner_maintenance.py
@@ -22,6 +22,8 @@ from gobby.shutdown_intent import ShutdownIntent
 from gobby.storage.sql_dialect import older_than_now_expr
 
 if TYPE_CHECKING:
+    from types import FrameType
+
     from gobby.mcp_proxy.metrics import ToolMetricsManager
     from gobby.memory.vectorstore import VectorStore
     from gobby.storage.hub.protocol import HubDatabase
@@ -728,7 +730,20 @@ def setup_signal_handlers(
         return handle_shutdown
 
     for sig in (signal.SIGTERM, signal.SIGINT):
-        loop.add_signal_handler(sig, _make_handler(sig))
+        handler = _make_handler(sig)
+        try:
+            loop.add_signal_handler(sig, handler)
+        except NotImplementedError:
+            # Windows event loops do not implement add_signal_handler. Fall back
+            # to signal.signal and marshal the callback onto the loop thread.
+            def _os_signal_handler(
+                _signum: int,
+                _frame: FrameType | None,
+                _handler: Callable[[], None] = handler,
+            ) -> None:
+                loop.call_soon_threadsafe(_handler)
+
+            signal.signal(sig, _os_signal_handler)
 
 
 def cleanup_pid_file() -> None:

--- a/tests/agents/test_pty_bridge_platform.py
+++ b/tests/agents/test_pty_bridge_platform.py
@@ -7,14 +7,15 @@ Windows. The module must import everywhere and degrade at call time instead.
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from gobby.agents.tmux import pty_bridge
-from gobby.agents.tmux.pty_bridge import TmuxPTYBridge
+from gobby.agents.tmux.pty_bridge import BridgeInfo, TmuxPTYBridge
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
 
 
 class TestPtyBridgePlatformGuards:
@@ -46,8 +47,20 @@ class TestPtyBridgePlatformGuards:
         mock_openpty.assert_not_called()
 
     async def test_resize_returns_none_when_unsupported(self) -> None:
-        """resize() already returns None on failure; keep that contract."""
+        """resize() returns None without ioctl when the platform lacks PTY support."""
         bridge = TmuxPTYBridge()
+        bridge._bridges["streaming-id"] = BridgeInfo(
+            master_fd=42,
+            proc=MagicMock(),
+            session_name="session",
+            socket_name="socket",
+            created_at=datetime.now(UTC),
+        )
 
-        with patch.object(pty_bridge, "PTY_SUPPORTED", False):
-            assert await bridge.resize("missing-id", 24, 80) is None
+        with (
+            patch.object(pty_bridge, "PTY_SUPPORTED", False),
+            patch.object(pty_bridge, "fcntl", MagicMock()) as mock_fcntl,
+        ):
+            assert await bridge.resize("streaming-id", 24, 80) is None
+
+        mock_fcntl.ioctl.assert_not_called()

--- a/tests/agents/test_pty_bridge_platform.py
+++ b/tests/agents/test_pty_bridge_platform.py
@@ -1,0 +1,53 @@
+"""Platform guards for the tmux PTY bridge.
+
+``fcntl``/``termios`` are POSIX-only. Importing them at module scope made the
+whole ``gobby.agents.tmux`` package — and therefore daemon startup — fail on
+Windows. The module must import everywhere and degrade at call time instead.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from gobby.agents.tmux import pty_bridge
+from gobby.agents.tmux.pty_bridge import TmuxPTYBridge
+
+pytestmark = pytest.mark.unit
+
+
+class TestPtyBridgePlatformGuards:
+    def test_module_exposes_support_flag(self) -> None:
+        """Importing the module must never raise, on any platform."""
+        assert isinstance(pty_bridge.PTY_SUPPORTED, bool)
+
+    async def test_attach_raises_clear_error_when_unsupported(self) -> None:
+        """attach() should explain the platform limit, not AttributeError."""
+        bridge = TmuxPTYBridge()
+
+        with patch.object(pty_bridge, "PTY_SUPPORTED", False):
+            with pytest.raises(RuntimeError, match="POSIX"):
+                await bridge.attach("session", "streaming-id")
+
+    async def test_attach_does_not_open_a_pty_when_unsupported(self) -> None:
+        """The guard must fire before any POSIX-only syscall."""
+        bridge = TmuxPTYBridge()
+
+        with (
+            patch.object(pty_bridge, "PTY_SUPPORTED", False),
+            # create=True: os.openpty does not exist on Windows, which is the
+            # very platform this guard protects.
+            patch("os.openpty", create=True) as mock_openpty,
+        ):
+            with pytest.raises(RuntimeError):
+                await bridge.attach("session", "streaming-id")
+
+        mock_openpty.assert_not_called()
+
+    async def test_resize_returns_none_when_unsupported(self) -> None:
+        """resize() already returns None on failure; keep that contract."""
+        bridge = TmuxPTYBridge()
+
+        with patch.object(pty_bridge, "PTY_SUPPORTED", False):
+            assert await bridge.resize("missing-id", 24, 80) is None

--- a/tests/test_signal_handler_platform.py
+++ b/tests/test_signal_handler_platform.py
@@ -1,0 +1,84 @@
+"""Platform fallback for daemon signal handling.
+
+``loop.add_signal_handler`` is Unix-only; Windows event loops raise
+``NotImplementedError``. ``setup_signal_handlers`` must fall back to
+``signal.signal`` so the daemon can still shut down gracefully.
+"""
+
+from __future__ import annotations
+
+import signal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gobby.runner_maintenance import setup_signal_handlers
+
+pytestmark = pytest.mark.unit
+
+
+class TestSetupSignalHandlers:
+    async def test_uses_loop_handlers_when_supported(self) -> None:
+        """On POSIX the asyncio loop registers the handlers directly."""
+        loop = MagicMock()
+
+        with patch("asyncio.get_running_loop", return_value=loop):
+            setup_signal_handlers(lambda: None)
+
+        registered = {call.args[0] for call in loop.add_signal_handler.call_args_list}
+        assert registered == {signal.SIGTERM, signal.SIGINT}
+        loop.call_soon_threadsafe.assert_not_called()
+
+    async def test_falls_back_to_signal_signal_on_windows(self) -> None:
+        """A loop without add_signal_handler must not abort daemon startup."""
+        loop = MagicMock()
+        loop.add_signal_handler.side_effect = NotImplementedError
+
+        with (
+            patch("asyncio.get_running_loop", return_value=loop),
+            patch("signal.signal") as mock_signal,
+        ):
+            setup_signal_handlers(lambda: None)
+
+        registered = {call.args[0] for call in mock_signal.call_args_list}
+        assert registered == {signal.SIGTERM, signal.SIGINT}
+
+    async def test_fallback_handler_marshals_onto_the_loop(self) -> None:
+        """The signal.signal handler must hop back onto the loop thread."""
+        loop = MagicMock()
+        loop.add_signal_handler.side_effect = NotImplementedError
+        shutdown_called = False
+
+        def shutdown() -> None:
+            nonlocal shutdown_called
+            shutdown_called = True
+
+        with (
+            patch("asyncio.get_running_loop", return_value=loop),
+            patch("signal.signal") as mock_signal,
+        ):
+            setup_signal_handlers(shutdown)
+
+        # Invoke the handler signal.signal was given, as the OS would.
+        handler = mock_signal.call_args_list[0].args[1]
+        handler(signal.SIGTERM, None)
+
+        loop.call_soon_threadsafe.assert_called_once()
+        # The queued callable is the real shutdown path, not the raw signal handler.
+        loop.call_soon_threadsafe.call_args.args[0]()
+        assert shutdown_called is True
+
+    async def test_fallback_binds_each_signal_to_its_own_handler(self) -> None:
+        """Late binding in the loop must not collapse both signals onto one handler."""
+        loop = MagicMock()
+        loop.add_signal_handler.side_effect = NotImplementedError
+
+        with (
+            patch("asyncio.get_running_loop", return_value=loop),
+            patch("signal.signal") as mock_signal,
+        ):
+            setup_signal_handlers(lambda: None)
+
+        handlers = [call.args[1] for call in mock_signal.call_args_list]
+        assert len(handlers) == 2
+        assert handlers[0] is not handlers[1]

--- a/tests/test_signal_handler_platform.py
+++ b/tests/test_signal_handler_platform.py
@@ -14,7 +14,7 @@ import pytest
 
 from gobby.runner_maintenance import setup_signal_handlers
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
 
 
 class TestSetupSignalHandlers:
@@ -82,3 +82,11 @@ class TestSetupSignalHandlers:
         handlers = [call.args[1] for call in mock_signal.call_args_list]
         assert len(handlers) == 2
         assert handlers[0] is not handlers[1]
+
+        # Both OS handlers must marshal distinct callables onto the loop.
+        handlers[0](signal.SIGTERM, None)
+        handlers[1](signal.SIGINT, None)
+
+        assert loop.call_soon_threadsafe.call_count == 2
+        queued = [call.args[0] for call in loop.call_soon_threadsafe.call_args_list]
+        assert queued[0] is not queued[1]


### PR DESCRIPTION
## Summary

The Gobby daemon cannot start on Windows. Two independent, sequential blockers each kill it during startup; this PR fixes both, so `gobby start` reaches a running daemon.

Neither is reachable on Linux or macOS — the changes are no-ops on POSIX.

## Changes

- **`agents/tmux/pty_bridge.py`** — guard the POSIX-only `fcntl`/`termios` imports behind `try/except ImportError` and expose `PTY_SUPPORTED`. `attach()` raises a clear `RuntimeError` instead of an `AttributeError`; `resize()` keeps its existing "return `None` on failure" contract. The guard sits *after* the duplicate-bridge validation and immediately before the first POSIX syscall (`os.openpty`), so platform-independent behaviour is unchanged.
- **`runner_maintenance.py`** — `setup_signal_handlers` falls back to `signal.signal` when `loop.add_signal_handler` raises `NotImplementedError`, marshalling onto the loop thread via `call_soon_threadsafe`. Each signal binds its own handler through a default argument, so SIGTERM and SIGINT do not collapse onto one callback via late binding.
- **Tests** — `tests/test_signal_handler_platform.py` (4) and `tests/agents/test_pty_bridge_platform.py` (4). Both suites exercise the fallback paths on *any* platform by simulating the unsupported case, so POSIX CI covers the Windows behaviour.

### Why the daemon needed both

`gobby.agents.tmux.__init__` imports `TmuxPTYBridge` unconditionally, and `runner_init.orchestration` pulls that package in — so the `fcntl` import aborts startup before the runner exists. With that fixed, `run_daemon` then dies on `add_signal_handler`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

- [x] Tests pass locally (`uv run pytest`)
- [x] New tests added for new functionality
- [x] Linting passes (`uv run ruff check src/`)
- [x] Type checking passes (`uv run mypy src/`)

Verified on Windows 11 Pro 10.0.26220 / Python 3.13, measured against clean `main` as the baseline:

| Suite | Before | After |
|---|---|---|
| `tests/agents/test_tmux.py` | **collection error** — 0 tests runnable | 90 passed, 11 failed |
| `tests/test_runner_shutdown.py` + `tests/test_runner_lifecycle.py` | 41 failed, 31 passed | 1 failed, 71 passed |
| new platform tests | — | 8 passed |

`mypy` on the two changed files reports the same 6 pre-existing errors before and after (all Windows-only `os.openpty`/`ioctl` attr-defined artifacts of running mypy on Windows); this PR adds none. `ruff check` and `ruff format --check` are clean.

End-to-end, `gobby start` now completes on Windows: health check passes and the daemon stays up.

### Remaining Windows failures are out of scope

The failures still listed above are pre-existing gaps unrelated to these two fixes, surfaced only because the modules can now be imported at all:

- Most of the `test_tmux.py` residue hardcodes POSIX expectations where `wsl_compat` correctly prefixes `wsl` (e.g. `test_base_args_default` expects `["tmux", ...]` but gets `["wsl", "tmux", ...]`).
- `test_run_with_websocket_server` fails on `main` too (there with `module 'gobby' has no attribute 'runner_init'`, a symptom of the same import cascade).

Happy to address those in a follow-up if you'd like them fixed rather than left as-is.

## Related Issues

Closes #26
Closes #27

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed — no docs change; Windows is not currently a documented platform. If a supported-platform note would help, tell me where and I'll add it.

## Note on scope

Windows isn't listed as supported in the README, though `agents/tmux/wsl_compat.py` suggests partial intent. These two changes are small and inert on POSIX, so they seemed worth offering regardless — but close this if a Windows daemon isn't a direction you want to take on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkgcVvP1MEo1ar2qPfT1kH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows compatibility for PTY-based tmux features.
  * PTY operations now fail clearly when unsupported instead of causing import or runtime errors.
  * Signal handling now works with Windows event loops through a safe fallback mechanism.

* **Tests**
  * Added coverage for cross-platform PTY behavior and signal-handler registration, including Windows-specific scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->